### PR TITLE
Switching to 'codetabs' gitbook plugin

### DIFF
--- a/1.2-domain-logic/command-model.md
+++ b/1.2-domain-logic/command-model.md
@@ -272,9 +272,9 @@ public class DoSomethingCommand {
 
 Let's see how we can configure an Aggregate:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 Configurer configurer = ...
 // to use defaults:
 configurer.configureAggreate(MyAggregate.class);
@@ -284,11 +284,9 @@ configurer.configureAggregate(
         AggregateConfigurer.defaultConfiguration(MyAggregate.class)
                            .configureCommandTargetResolver(c -> new CustomCommandTargetResolver())
 );
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 @Aggregate(commandTargetResolver = "customCommandTargetResolver")
 public class MyAggregate {...}
 ...
@@ -297,9 +295,8 @@ public class MyAggregate {...}
 public CommandTargetResolver customCommandTargetResolver() {
     return new CustomCommandTargetResolver();
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 `@CommandHandler` annotations are not limited to the aggregate root. Placing all command handlers in the root will sometimes lead to a large number of methods on the aggregate root, while many of them simply forward the invocation to one of the underlying entities. If that is the case, you may place the `@CommandHandler` annotation on one of the underlying entities' methods. For Axon to find these annotated methods, the field declaring the entity in the aggregate root must be marked with `@AggregateMember`. Note that only the declared type of the annotated field is inspected for command handlers. If a field value is null at the time an incoming command arrives for that entity, an exception is thrown.
 

--- a/1.2-domain-logic/event-handling.md
+++ b/1.2-domain-logic/event-handling.md
@@ -59,9 +59,8 @@ Event handling components are defined using an `EventHandlingConfiguration` clas
 
 To register objects with `@EventHandler` methods, use the `registerEventHandler()` method on the `EventHandlingConfiguration`:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 // define an EventHandlingConfiguration
 EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
     .registerEventHandler(conf -> new MyEventHandlerClass());
@@ -69,18 +68,15 @@ EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
 // the module needs to be registered with the Axon Configuration
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerModule(ehConfiguration);
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 @Component
 public class MyEventHandlerClass {
     // contains @EventHandler(s)
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 See [Event handling configuration](../1.3-infrastructure-components/spring-boot-autoconfiguration.md#event-handling-configuration) for details on registering event handlers using Spring AutoConfiguration.
 

--- a/1.2-domain-logic/query-handling.md
+++ b/1.2-domain-logic/query-handling.md
@@ -61,9 +61,8 @@ In the example above, the handler method of `SubHandler` will be invoked for que
 
 It is possible to register multiple query handlers for the same query name and type of response. When dispatching queries, the client can indicate whether he wants a result from one or from all available query handlers.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 // Sample query handler
 public class MyQueryHandler {
     @QueryHandler
@@ -77,11 +76,9 @@ public class MyQueryHandler {
 // To register your query handler
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerQueryHandler(conf -> new MyQueryHandler);
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 // Sample query handler
 @Component
 public class MyQueryHandler {
@@ -90,7 +87,6 @@ public class MyQueryHandler {
         return echo;
     }
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 

--- a/1.2-domain-logic/sagas.md
+++ b/1.2-domain-logic/sagas.md
@@ -144,9 +144,8 @@ Axon supports life cycle management through the `AnnotatedSagaManager`, which is
 
 When using the Configuration API, Axon will use sensible defaults for most components. However, it is highly recommended to define a `SagaStore` implementation to use. The `SagaStore` is the mechanism that 'physically' stores the saga instances somewhere. The `AnnotatedSagaRepository` \(the default\) uses the `SagaStore` to store and retrieve Saga instances as they are required.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.registerModule(
         SagaConfiguration.subscribingSagaManager(MySaga.class)
@@ -156,11 +155,9 @@ configurer.registerModule(
 
 // alternatively, it is possible to register a single SagaStore for all Saga types:
 configurer.registerComponent(SagaStore.class, c -> new JpaSagaStore(...));
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 @Saga(sagaStore = "mySagaStore")
 public class MySaga {...}
 ...
@@ -169,9 +166,8 @@ public class MySaga {...}
 public SagaStore mySagaStore() {
     return new MongoSagaStore(...); // default is JpaSagaStore
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 ### Saga repository and saga store
 

--- a/1.3-infrastructure-components/event-processing.md
+++ b/1.3-infrastructure-components/event-processing.md
@@ -12,16 +12,13 @@ The `EventBus` is the mechanism that dispatches events to the subscribed event h
 
 When using the Configuration API, the `SimpleEventBus` is used by default. To configure the `EmbeddedEventStore` instead, you need to supply an implementation of a StorageEngine, which does the actual storage of Events.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 // somewhere in configuration
 @Bean
 public EventStorageEngine eventStorageEngine() {
@@ -29,9 +26,8 @@ public EventStorageEngine eventStorageEngine() {
 }
 // When a EventStorageEngine is provided, the EmbeddedEventStore is configured as the EventStore.
 // And if JPA configuration is detected JpaEventStorageEngine is configured as EventStorageEngine.
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 ## Event Processors
 

--- a/1.4-advanced-tuning/advanced-customizations.md
+++ b/1.4-advanced-tuning/advanced-customizations.md
@@ -24,9 +24,8 @@ There is an implicit ordering between the configurable serializer. If no `EventS
 
 See the following example on how to configure each serializer specifically, were we use `XStreamSerializer` as the default and `JacksonSerializer` for all our messages:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 public class SerializerConfiguration {
 
     public void serializerConfiguration(Configurer configurer) {
@@ -40,29 +39,24 @@ public class SerializerConfiguration {
                   .configureEventSerializer(configuration -> messageSerializer);
     }
 }
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration - Properties file" %}
-```text
+{%- language name="Spring Boot - Properties", type="txt" -%}
+
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon.serializer.general
 axon.serializer.events
 axon.serializer.messages
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration - YML file" %}
-```yaml
+{%- language name="Spring Boot - YML", type="txt" -%}
+
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon:
     serializer:
         general: 
         events: 
         messages:
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 ## Meta Annotations
 
@@ -158,24 +152,21 @@ To skip all handling of the handler then just throw an exception.
 
 It is possible to configure `HandlerDefinition` with Axon `Configuration`. If you are using Spring Boot defining `HandlerDefintion`s and `HandlerEnhancerDefinition`s as beans is sufficient \(Axon autoconfiguration will pick them up and configure within Axon `Configuration`\).
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.registerHandlerDefinition(c -> new MethodCommandHandlerDefinition());
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 // somewhere in configuration
 @Bean
 public HandlerDefinition eventStorageEngine() {
     return new MethodCommandHandlerDefinition(); 
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 ## Filtering Event Storage Engine
 

--- a/1.4-advanced-tuning/metrics-and-monitoring.md
+++ b/1.4-advanced-tuning/metrics-and-monitoring.md
@@ -17,9 +17,8 @@ Internally, the `axon-metrics` module uses [Dropwizard Metrics](https://metrics.
 
 You are free to configure any combination of `MessageMonitors` through constructors on your messaging components, and even simpler by using the [Configuration API](../1.1-concepts/configuration-api.md). The `GlobalMetricRegistry` contained in the `axon-metrics` module provides a set of sensible defaults per type of messaging component. The following example shows you how to configure default metrics for your message handling components:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 public class MetricsConfiguration {
 
     public Configurer buildConfigurer() {
@@ -33,16 +32,13 @@ public class MetricsConfiguration {
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
 }
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```text
+{%- language name="Spring Boot AutoConfiguration", type="txt" -%}
+
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 If you want to have more specific metrics on a message handling component like the `EventBus`, you can do the following:
 
@@ -85,9 +81,8 @@ One import aspect in regards to this is tracing a given message. To that end the
 
 For configuring the `MessageOriginProvider` you can do the following:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+
 public class MonitoringConfiguration {
 
     public Configurer buildConfigurer() {
@@ -103,11 +98,9 @@ public class MonitoringConfiguration {
     }
 
 }
-```
-{% endtab %}
 
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
+
 public class MonitoringConfiguration {
 
     // When using Spring Boot, simply defining a CorrelationDataProvider bean is sufficient
@@ -116,9 +109,8 @@ public class MonitoringConfiguration {
     }
 
 }
-```
-{% endtab %}
-{% endtabs %}
+
+{%- endcodetabs %}
 
 ### Interceptor Logging
 

--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["ga", "anchors", "codetabs"],
+  "plugins": ["ga", "anchors", "codetabs", "hints"],
   "pluginsConfig": {
     "ga": {
       "token": "UA-180286-13"


### PR DESCRIPTION
We are using `codetabs` plugin to render our tabs in the guide now.
You should be able to serve gitbook guide locally on http://localhost:4000: `$ gitbook serve`


Gitbook local installation: https://toolchain.gitbook.com/setup.html


