### PR TITLE
Revert "Switching to 'codetabs' gitbook plugin"

### DIFF
--- a/1.2-domain-logic/command-model.md
+++ b/1.2-domain-logic/command-model.md
@@ -272,9 +272,9 @@ public class DoSomethingCommand {
 
 Let's see how we can configure an Aggregate:
 
-
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 Configurer configurer = ...
 // to use defaults:
 configurer.configureAggreate(MyAggregate.class);
@@ -284,9 +284,11 @@ configurer.configureAggregate(
         AggregateConfigurer.defaultConfiguration(MyAggregate.class)
                            .configureCommandTargetResolver(c -> new CustomCommandTargetResolver())
 );
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 @Aggregate(commandTargetResolver = "customCommandTargetResolver")
 public class MyAggregate {...}
 ...
@@ -295,8 +297,9 @@ public class MyAggregate {...}
 public CommandTargetResolver customCommandTargetResolver() {
     return new CustomCommandTargetResolver();
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 `@CommandHandler` annotations are not limited to the aggregate root. Placing all command handlers in the root will sometimes lead to a large number of methods on the aggregate root, while many of them simply forward the invocation to one of the underlying entities. If that is the case, you may place the `@CommandHandler` annotation on one of the underlying entities' methods. For Axon to find these annotated methods, the field declaring the entity in the aggregate root must be marked with `@AggregateMember`. Note that only the declared type of the annotated field is inspected for command handlers. If a field value is null at the time an incoming command arrives for that entity, an exception is thrown.
 

--- a/1.2-domain-logic/event-handling.md
+++ b/1.2-domain-logic/event-handling.md
@@ -59,8 +59,9 @@ Event handling components are defined using an `EventHandlingConfiguration` clas
 
 To register objects with `@EventHandler` methods, use the `registerEventHandler()` method on the `EventHandlingConfiguration`:
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 // define an EventHandlingConfiguration
 EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
     .registerEventHandler(conf -> new MyEventHandlerClass());
@@ -68,15 +69,18 @@ EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
 // the module needs to be registered with the Axon Configuration
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerModule(ehConfiguration);
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 @Component
 public class MyEventHandlerClass {
     // contains @EventHandler(s)
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 See [Event handling configuration](../1.3-infrastructure-components/spring-boot-autoconfiguration.md#event-handling-configuration) for details on registering event handlers using Spring AutoConfiguration.
 

--- a/1.2-domain-logic/query-handling.md
+++ b/1.2-domain-logic/query-handling.md
@@ -61,8 +61,9 @@ In the example above, the handler method of `SubHandler` will be invoked for que
 
 It is possible to register multiple query handlers for the same query name and type of response. When dispatching queries, the client can indicate whether he wants a result from one or from all available query handlers.
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 // Sample query handler
 public class MyQueryHandler {
     @QueryHandler
@@ -76,9 +77,11 @@ public class MyQueryHandler {
 // To register your query handler
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerQueryHandler(conf -> new MyQueryHandler);
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 // Sample query handler
 @Component
 public class MyQueryHandler {
@@ -87,6 +90,7 @@ public class MyQueryHandler {
         return echo;
     }
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 

--- a/1.2-domain-logic/sagas.md
+++ b/1.2-domain-logic/sagas.md
@@ -144,8 +144,9 @@ Axon supports life cycle management through the `AnnotatedSagaManager`, which is
 
 When using the Configuration API, Axon will use sensible defaults for most components. However, it is highly recommended to define a `SagaStore` implementation to use. The `SagaStore` is the mechanism that 'physically' stores the saga instances somewhere. The `AnnotatedSagaRepository` \(the default\) uses the `SagaStore` to store and retrieve Saga instances as they are required.
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.registerModule(
         SagaConfiguration.subscribingSagaManager(MySaga.class)
@@ -155,9 +156,11 @@ configurer.registerModule(
 
 // alternatively, it is possible to register a single SagaStore for all Saga types:
 configurer.registerComponent(SagaStore.class, c -> new JpaSagaStore(...));
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 @Saga(sagaStore = "mySagaStore")
 public class MySaga {...}
 ...
@@ -166,8 +169,9 @@ public class MySaga {...}
 public SagaStore mySagaStore() {
     return new MongoSagaStore(...); // default is JpaSagaStore
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 ### Saga repository and saga store
 

--- a/1.3-infrastructure-components/event-processing.md
+++ b/1.3-infrastructure-components/event-processing.md
@@ -12,13 +12,16 @@ The `EventBus` is the mechanism that dispatches events to the subscribed event h
 
 When using the Configuration API, the `SimpleEventBus` is used by default. To configure the `EmbeddedEventStore` instead, you need to supply an implementation of a StorageEngine, which does the actual storage of Events.
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 // somewhere in configuration
 @Bean
 public EventStorageEngine eventStorageEngine() {
@@ -26,8 +29,9 @@ public EventStorageEngine eventStorageEngine() {
 }
 // When a EventStorageEngine is provided, the EmbeddedEventStore is configured as the EventStore.
 // And if JPA configuration is detected JpaEventStorageEngine is configured as EventStorageEngine.
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 ## Event Processors
 

--- a/1.4-advanced-tuning/advanced-customizations.md
+++ b/1.4-advanced-tuning/advanced-customizations.md
@@ -24,8 +24,9 @@ There is an implicit ordering between the configurable serializer. If no `EventS
 
 See the following example on how to configure each serializer specifically, were we use `XStreamSerializer` as the default and `JacksonSerializer` for all our messages:
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 public class SerializerConfiguration {
 
     public void serializerConfiguration(Configurer configurer) {
@@ -39,24 +40,29 @@ public class SerializerConfiguration {
                   .configureEventSerializer(configuration -> messageSerializer);
     }
 }
+```
+{% endtab %}
 
-{%- language name="Spring Boot - Properties", type="txt" -%}
-
+{% tab title="Spring Boot AutoConfiguration - Properties file" %}
+```text
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon.serializer.general
 axon.serializer.events
 axon.serializer.messages
+```
+{% endtab %}
 
-{%- language name="Spring Boot - YML", type="txt" -%}
-
+{% tab title="Spring Boot AutoConfiguration - YML file" %}
+```yaml
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon:
     serializer:
         general: 
         events: 
         messages:
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 ## Meta Annotations
 
@@ -152,21 +158,24 @@ To skip all handling of the handler then just throw an exception.
 
 It is possible to configure `HandlerDefinition` with Axon `Configuration`. If you are using Spring Boot defining `HandlerDefintion`s and `HandlerEnhancerDefinition`s as beans is sufficient \(Axon autoconfiguration will pick them up and configure within Axon `Configuration`\).
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.registerHandlerDefinition(c -> new MethodCommandHandlerDefinition());
+```
+{% endtab %}
 
-
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 // somewhere in configuration
 @Bean
 public HandlerDefinition eventStorageEngine() {
     return new MethodCommandHandlerDefinition(); 
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 ## Filtering Event Storage Engine
 

--- a/1.4-advanced-tuning/metrics-and-monitoring.md
+++ b/1.4-advanced-tuning/metrics-and-monitoring.md
@@ -17,8 +17,9 @@ Internally, the `axon-metrics` module uses [Dropwizard Metrics](https://metrics.
 
 You are free to configure any combination of `MessageMonitors` through constructors on your messaging components, and even simpler by using the [Configuration API](../1.1-concepts/configuration-api.md). The `GlobalMetricRegistry` contained in the `axon-metrics` module provides a set of sensible defaults per type of messaging component. The following example shows you how to configure default metrics for your message handling components:
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 public class MetricsConfiguration {
 
     public Configurer buildConfigurer() {
@@ -32,13 +33,16 @@ public class MetricsConfiguration {
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
 }
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="txt" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```text
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 If you want to have more specific metrics on a message handling component like the `EventBus`, you can do the following:
 
@@ -81,8 +85,9 @@ One import aspect in regards to this is tracing a given message. To that end the
 
 For configuring the `MessageOriginProvider` you can do the following:
 
-{% codetabs name="Axon Configuration API", type="java" -%}
-
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 public class MonitoringConfiguration {
 
     public Configurer buildConfigurer() {
@@ -98,9 +103,11 @@ public class MonitoringConfiguration {
     }
 
 }
+```
+{% endtab %}
 
-{%- language name="Spring Boot AutoConfiguration", type="java" -%}
-
+{% tab title="Spring Boot AutoConfiguration" %}
+```java
 public class MonitoringConfiguration {
 
     // When using Spring Boot, simply defining a CorrelationDataProvider bean is sufficient
@@ -109,8 +116,9 @@ public class MonitoringConfiguration {
     }
 
 }
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 ### Interceptor Logging
 

--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["ga", "anchors", "codetabs", "hints"],
+  "plugins": ["ga", "anchors", "codetabs"],
   "pluginsConfig": {
     "ga": {
       "token": "UA-180286-13"


### PR DESCRIPTION
Reverts AxonIQ/reference-guide#39

The `codetabs` syntax we introduces is not inline with the latest of Gitbook.
We have to use this syntax (as we did before):
```
{% tabs %} {% tab title="First Tab" %} My first tab content {% endtab %}

{% tab title="Second Tab" %} My second tab content {% endtab %} {% endtabs %}
```
`gitbook cli` cant be used locally ...
Please revert