### PR TITLE
Guide adjustments in regards to new features introduces in Axon Framework 4.1

### DIFF
--- a/configuring-infrastructure-components/event-processing/event-processors.md
+++ b/configuring-infrastructure-components/event-processing/event-processors.md
@@ -139,7 +139,7 @@ public SagaConfiguration<MySaga> mySagaConfigurationBean() {
 
 Errors are inevitable and depending on where they happen, you may want to respond differently. 
 
-By default, exceptions that are raised by Event Handlers are logged, and processing continues with the next events. Exceptions that are thrown when a processor is trying to commit a transaction, update a token, or in any other other part of the process, the exception is propagated. In case of a Tracking Processor, this means the processor will go into error mode, releasing any tokens and retryin at an incremental interval (starting at 1 second, up to max 60 seconds). Subscribing processor will report a publication error to the component that provided the Event.
+By default, exceptions that are raised by Event Handlers are logged, and processing continues with the next events. Exceptions that are thrown when a processor is trying to commit a transaction, update a token, or in any other other part of the process, the exception is propagated. In case of a Tracking Processor, this means the processor will go into error mode, releasing any tokens and retrying at an incremental interval (starting at 1 second, up to max 60 seconds). Subscribing processor will report a publication error to the component that provided the Event.
 
 To change this behavior, there are two levels at which you can customize how Axon deals with Exceptions:
 
@@ -270,6 +270,12 @@ Note that you can override the token store to use with tracking processors in th
 ## Event Tracker Status
 
 In some cases it might be useful to know the state of a Tracking Event Processor for each of its segment. One of those cases could be when we want to rebuild our view model and we want to check when the Processor is caught up with all the events. For cases like these, the `TrackingEventProcessor` exposes `processingStatus()` method, which returns a map where the key is the segment identifier, and the value is the event processing status. Based on this status we can determine whether the Processor is caught up and/or is replaying, and we can verify the Tracking Token of its segments.
+
+## Splitting and Merging Tracking Tokens
+
+It is possible to tune the performance of tracking processors by increasing the number of threads processing events on high load by splitting segments and reducing the number of threads when load reduces by merging segments. This can be done using through the Axon Server API or through Axon Framework using the methods `splitSegment(int segmentId)` and `mergeSegment(int segmentId)` from `TrackingEventProcessor` by providing the segmentId of the segment you want to split or merge.
+
+Note: By splitting/merging using Axon Server the most appropriate segment to split or merge is chosen for you so that segments are balanced but the decision which segment to split or merge is to be decided by the developer when using Axon Framework.
 
 ## Parallel processing
 

--- a/configuring-infrastructure-components/event-processing/event-processors.md
+++ b/configuring-infrastructure-components/event-processing/event-processors.md
@@ -273,7 +273,7 @@ In some cases it might be useful to know the state of a Tracking Event Processor
 
 ## Splitting and Merging Tracking Tokens
 
-It is possible to tune the performance of tracking processors by increasing the number of threads processing events on high load by splitting segments and reducing the number of threads when load reduces by merging segments. This can be done using through the Axon Server API or through Axon Framework using the methods `splitSegment(int segmentId)` and `mergeSegment(int segmentId)` from `TrackingEventProcessor` by providing the segmentId of the segment you want to split or merge.
+It is possible to tune the performance of tracking processors by increasing the number of threads processing events on high load by splitting segments and reducing the number of threads when load reduces by merging segments.  Splitting and merging are allowed at runtime allowing you to dynamically control the number of segments. This can be done through the Axon Server API or through Axon Framework using the methods `splitSegment(int segmentId)` and `mergeSegment(int segmentId)` from `TrackingEventProcessor` by providing the segmentId of the segment you want to split or merge.
 
 Note: By splitting/merging using Axon Server the most appropriate segment to split or merge is chosen for you so that segments are balanced but the decision which segment to split or merge is to be decided by the developer when using Axon Framework.
 

--- a/configuring-infrastructure-components/event-processing/event-processors.md
+++ b/configuring-infrastructure-components/event-processing/event-processors.md
@@ -139,7 +139,12 @@ public SagaConfiguration<MySaga> mySagaConfigurationBean() {
 
 Errors are inevitable and depending on where they happen, you may want to respond differently. 
 
-By default, exceptions that are raised by Event Handlers are logged, and processing continues with the next events. Exceptions that are thrown when a processor is trying to commit a transaction, update a token, or in any other other part of the process, the exception is propagated. In case of a Tracking Processor, this means the processor will go into error mode, releasing any tokens and retrying at an incremental interval (starting at 1 second, up to max 60 seconds). Subscribing processor will report a publication error to the component that provided the Event.
+By default, exceptions that are raised by Event Handlers are logged, and processing continues with the next events. 
+Exceptions that are thrown when a processor is trying to commit a transaction, update a token,
+ or in any other other part of the process, the exception is propagated. 
+In case of a Tracking Processor, this means the processor will go into error mode,
+ releasing any tokens and retrying at an incremental interval (starting at 1 second, up to max 60 seconds). 
+Subscribing processor will report a publication error to the component that provided the Event.
 
 To change this behavior, there are two levels at which you can customize how Axon deals with Exceptions:
 
@@ -273,9 +278,18 @@ In some cases it might be useful to know the state of a Tracking Event Processor
 
 ## Splitting and Merging Tracking Tokens
 
-It is possible to tune the performance of tracking processors by increasing the number of threads processing events on high load by splitting segments and reducing the number of threads when load reduces by merging segments.  Splitting and merging are allowed at runtime allowing you to dynamically control the number of segments. This can be done through the Axon Server API or through Axon Framework using the methods `splitSegment(int segmentId)` and `mergeSegment(int segmentId)` from `TrackingEventProcessor` by providing the segmentId of the segment you want to split or merge.
+It is possible to tune the performance of Tracking Processors by increasing the number of threads processing events on
+ high load by splitting segments and reducing the number of threads when load reduces by merging segments.  
+Splitting and merging are allowed at runtime allowing you to dynamically control the number of segments. 
+This can be done through the Axon Server API or through Axon Framework using the methods `splitSegment(int segmentId)`
+ and `mergeSegment(int segmentId)` from `TrackingEventProcessor` by providing the segmentId of the segment you want to split or merge.
 
-Note: By splitting/merging using Axon Server the most appropriate segment to split or merge is chosen for you so that segments are balanced but the decision which segment to split or merge is to be decided by the developer when using Axon Framework.
+> **Segment Selection Considerations** 
+> 
+> By splitting/merging using Axon Server the most appropriate segment to split or merge is chosen for you.
+> When using the Axon Framework API directly, the segment to split/merge should be deduced by the developer themselves:
+>  * Split: for fair balancing, a split is ideally performed on the biggest segment
+>  * Merge: for fair balancing, a merge is ideally performed on the smallest segment
 
 ## Parallel processing
 

--- a/implementing-domain-logic/event-handling/dispatching-events.md
+++ b/implementing-domain-logic/event-handling/dispatching-events.md
@@ -58,20 +58,13 @@ This is necessary for [Event Sourcing](../command-handling/aggregate.md#basic-ag
 
 In the vast majority of cases, the [Aggregates](#dispatching-events-from-an-aggregate) will publish events by applying them. 
 However, occasionally, it is necessary to publish an event (possibly from within another component),
- directly to the Event Bus:
+ directly to the Event Gateway:
 
 ```java
-private EventBus eventBus; // 1.
+private EventGateway eventGateway;
 
 public void dispatchEvent() {
-    // 2. & 3.
-    eventBus.publish(GenericEventMessage.asEventMessage(new CardIssuedEvent("cardId", 100, "shopId")));
+    eventGateway.publish(new CardIssuedEvent("cardId", 100, "shopId"));
 }
 // omitted class and constructor 
 ```
-
-1. The `EventBus` interface which allows the publication of events.
-2. The `GenericEventMessage#asEventMessage(Object)` method allows you to wrap any object into an `EventMessage`. 
-If the passed object is already an EventMessage, it is simply returned.
-3. `publish(EventMessage...)` is used to actually publish an event.
-As shown, the event payload, the `CardIssuedEvent`, should be wrapped in an `EventMessage`. 

--- a/implementing-domain-logic/event-handling/handling-events.md
+++ b/implementing-domain-logic/event-handling/handling-events.md
@@ -62,11 +62,15 @@ To register objects with `@EventHandler` methods, use the `registerEventHandler(
 {% tab title="Axon Configuration API" %}
 ```java
 Configurer configurer = DefaultConfigurer.defaultConfiguration()
+                                         .registerEventHandler(conf -> new MyEventHandlerClass()));
+```
+or with configuring the event processor
+```java
+Configurer configurer = DefaultConfigurer.defaultConfiguration()
                                          .eventProcessing(eventProcessingConfigurer -> eventProcessingConfigurer
                                              .registerEventHandler(conf -> new MyEventHandlerClass()));
 ```
 {% endtab %}
-
 {% tab title="Spring Boot AutoConfiguration" %}
 ```java
 @Component

--- a/implementing-domain-logic/query-handling/handling-queries.md
+++ b/implementing-domain-logic/query-handling/handling-queries.md
@@ -27,19 +27,19 @@ Note that similar to command handling, and unlike event handling, query handling
 // and    a single instance of SubHandler is registered
 
 public class TopHandler {
-
-    @QueryHandler
-    public MyResult handle(QueryA query) {
-    }
-
-    @QueryHandler
-    public MyResult handle(QueryB query) {
-    }
-
-    @QueryHandler
-    public MyResult handle(QueryC query) {
-    }
-}
+ 
+     @QueryHandler
+     public MyResult handle(QueryA query) {
+     }
+ 
+     @QueryHandler
+     public MyResult handle(QueryB query) {
+     }
+ 
+     @QueryHandler
+     public MyResult handle(QueryC query) {
+     }
+ }
 
 public class SubHandler extends TopHandler {
 
@@ -50,6 +50,17 @@ public class SubHandler extends TopHandler {
 ```
 
 In the example above, the handler method of `SubHandler` will be invoked for queries for `QueryB` and result `MyResult` the handler methods of `TopHandler` are invoked for queries for `QueryA` and `QueryC` and result `MyResult`.
+
+Note: It is also possible for queries to return primitive data types.
+
+```java
+public class QueryHandler {
+ 
+     @QueryHandler
+     public float handle(QueryA query) {
+     }
+ }
+```
 
 ## Registering Query Handlers
 

--- a/implementing-domain-logic/query-handling/handling-queries.md
+++ b/implementing-domain-logic/query-handling/handling-queries.md
@@ -51,7 +51,10 @@ public class SubHandler extends TopHandler {
 
 In the example above, the handler method of `SubHandler` will be invoked for queries for `QueryB` and result `MyResult` the handler methods of `TopHandler` are invoked for queries for `QueryA` and `QueryC` and result `MyResult`.
 
-Note: It is also possible for queries to return primitive data types.
+> **Query Response Types**
+> 
+> Among the usual Objects, it is also possible for queries to return primitive data types.
+> Upon wrapping such a response for the querying party, the boxed types will be used. 
 
 ```java
 public class QueryHandler {


### PR DESCRIPTION
This PR introduce adjustments to the documentation in regards to new features which have been introduced in Axon Framework 4.1.
The following features now have been documented:

- [Allow TrackingEventProcessor segments to be split and merged](https://github.com/AxonFramework/AxonFramework/pull/969)
- [Introduce an EventGateway to simplify Event Message publication](https://github.com/AxonFramework/AxonFramework/issues/954)
- [Add a "registerEventHandler" shorthand to Configuration](https://github.com/AxonFramework/AxonFramework/issues/887)
- [The QueryBus should be able to cope with primitives](https://github.com/AxonFramework/AxonFramework/issues/650)
