### PR TITLE
Added localServiceInstance of type Registration to backup command router code example

### DIFF
--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -112,13 +112,15 @@ public class MyApplicationConfiguration {
     @Bean
     public CommandRouter springCloudHttpBackupCommandRouter(
                              DiscoveryClient discoveryClient, 
-                             RestTemplate restTemplate, 
+                             RestTemplate restTemplate,
+                             Registration localServiceInstance,							 
                              @Value("${axon.distributed.spring-cloud.fallback-url}") 
                                          String messageRoutingInformationEndpoint) {
         return SpringCloudHttpBackupCommandRouter.builder()
                                                  .discoveryClient(discoveryClient)
                                                  .routingStrategy(new AnnotationRoutingStrategy())
                                                  .restTemplate(restTemplate)
+												 .localServiceInstance(localServiceInstance)
                                                  .messageRoutingInformationEndpoint(messageRoutingInformationEndpoint)
                                                  .build();
     }


### PR DESCRIPTION
When working with Spring Cloud Kubernetes I tried to setup the SpringCloudHttpBackupCommandRouter only to find the example code omitted the Registration object required by parent SpringCloudCommandRouter.  I figured I would do a PR to correct it.