### PR TITLE
Added Info about global clock to docs

### DIFF
--- a/configuring-infrastructure-components/deadlines.md
+++ b/configuring-infrastructure-components/deadlines.md
@@ -96,12 +96,18 @@ public void on() {
 
 ## Using Time In Your  Application
 
-A global clock has been exposed that can be used for any necessary java util Date operations. 
+In cases where applications need to access the clock, they can take advantage of the 
+clock used in the EventMessage, by accessing `GenericEventMessage.clock`. 
+This clock is set to Clock.systemUTC at runtime, and manipulated to simulate time during
+[testing](../implementing-domain-logic/command-handling/testing.md).
+
 ```java
 public void handle(PublishTime cmd) {
     apply(new TimePublishedEvent(GenericEventMessage.clock.instant()));
 }
 ```
 
-This clock defaults to `Clock.systemUTC()` in most runtime situations and is overriden during 
-[testing](../implementing-domain-logic/command-handling/testing.md) to be a constant value. 
+Note that the current timestamp is automatically added to the EventMessage.
+If handlers only need to rely on the timestamp the event was published, 
+they can access that timestamp directly, as described in 
+[Handling Events](../implementing-domain-logic/event-handling/handling-events.md).


### PR DESCRIPTION
Recently I had a use-case that relied on time in the event message. When attempting to test I ran into an issue with being able to inject java clocks. I was able to find out that there is a global clock that can be used but it wasn't easy to find.

I made a suggestion to add it to the docs on Stack Overflow and was asked to raise a PR.

This conversation can be followed here: 
https://stackoverflow.com/questions/60026771/how-can-i-test-an-aggregate-that-relies-on-time/60026833#60026833

Feel free to suggest better locations in the docs. I didn't want it to be too disruptive to what already exists.