### PR TITLE
update extension tracing guide

### DIFF
--- a/extensions/tracing.md
+++ b/extensions/tracing.md
@@ -25,9 +25,9 @@ The second dependency is [Jaeger](https://www.jaegertracing.io/) implementation 
 There are other supported tracers that can be used: LightStep, Instana, Apache SkyWalking, Datadog, Wavefront by VMware, Elastic APM and many more.
 
 ## Configuring the extension
-The extension could be disabled using the property `axon.extension.tracing.enabled` (default=TRUE). This will give you the possibility to turn it off for a certain environment.
+The extension can be disabled setting the property `axon.extension.tracing.enabled` to `false` (default=`true`). This will give you the possibility to turn it off when needed (e.g.: for a certain environment).
 
-In release 4.4 we introduced a fine-grained configuration of tracing span tags for command, event and query.  You can customize span tags easily, mixing and matching between available tag `messageId`, `aggregateId`, `messageType`, `payloadType`, `messageName` and `payload`. Take into account that some of the tags make sense on a certain span type, but not on another, and some of them have an hidden cost on network (such as payload). Use them wisely!
+Furthermore there is a more fine-grained configuration option of the tracing span tags on commands, events and queries.  You can customize span tags easily, mixing and matching between available tag `messageId`, `aggregateId`, `messageType`, `payloadType`, `messageName` and `payload`. Take into account that some of the tags make sense on a certain span type, but not on another, and some of them have an hidden cost on network (such as payload). Use them wisely!
 ```
 axon.extension.tracing.span.commandTags=messageId, messageType, payloadType, messageName
 axon.extension.tracing.span.eventTags=messageId, aggregateId, messageType, payloadType

--- a/extensions/tracing.md
+++ b/extensions/tracing.md
@@ -8,13 +8,13 @@ With this instrumentation, we can chain synchronous and asynchronous commands an
 <dependency>
   <groupId>org.axonframework.extensions.tracing</groupId>
   <artifactId>axon-tracing-spring-boot-starter</artifactId>
-  <version>4.1-M1</version>
+  <version>4.4</version>
 </dependency>
 
 <dependency>
   <groupId>io.opentracing.contrib</groupId>
   <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-  <version>1.0.1</version>
+  <version>3.2.2</version>
 </dependency>
 ```
 
@@ -24,3 +24,15 @@ The second dependency is [Jaeger](https://www.jaegertracing.io/) implementation 
 
 There are other supported tracers that can be used: LightStep, Instana, Apache SkyWalking, Datadog, Wavefront by VMware, Elastic APM and many more.
 
+## Configuring the extension
+The extension could be disabled using the property `axon.extension.tracing.enabled` (default=TRUE). This will give you the possibility to turn it off for a certain environment.
+
+In release 4.4 we introduced a fine-grained configuration of tracing span tags for command, event and query.  You can customize span tags easily, mixing and matching between available tag `messageId`, `aggregateId`, `messageType`, `payloadType`, `messageName` and `payload`. Take into account that some of the tags make sense on a certain span type, but not on another, and some of them have an hidden cost on network (such as payload). Use them wisely!
+```
+axon.extension.tracing.span.commandTags=messageId, messageType, payloadType, messageName
+axon.extension.tracing.span.eventTags=messageId, aggregateId, messageType, payloadType
+axon.extension.tracing.span.queryTags=messageId, messageType, payloadType, messageName
+```
+
+Above an example of the default value.
+Available tags field are listed in [MessageTag.java](https://github.com/AxonFramework/extension-tracing/blob/master/tracing/src/main/java/org/axonframework/extensions/tracing/MessageTag.java) class.


### PR DESCRIPTION
This PR updates 4.4 reference guide with new configuration possibility for Tracing Extension introduced with https://github.com/AxonFramework/extension-tracing/pull/78 and https://github.com/AxonFramework/extension-tracing/pull/55