### PR TITLE
Adjust the Spring Cloud page

### DIFF
--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -4,7 +4,7 @@ Spring Cloud is an alternative approach to distributing the command bus \(comman
 
 The Spring Cloud Extension uses the service registration and discovery mechanism described by [Spring Cloud](https://spring.io/projects/spring-cloud) for distributing the command bus. 
 You thus have the choice of which Spring Cloud implementation to use when discovering the routes to distribute your commands. 
-An example implementations is the Netflix' [Eureka Discovery/Eureka Server](https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html) combination or HashiCorp's [Consul](https://www.consul.io/use-cases/service-discovery-and-health-checking).
+An example of that would be Netflix' [Eureka Discovery/Eureka Server](https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html) combination or HashiCorp's [Consul](https://www.consul.io/use-cases/service-discovery-and-health-checking).
 
 To use the Spring Cloud components from Axon, make sure the `axon-springcloud` module is available on the classpath.
 The easiest way is to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -50,7 +50,7 @@ There are, however, a couple of additional things you can configure for this rou
 
 * `RoutingStrategy` - The component in charge of deciding which of the nodes receives the commands consistently. By default a `AnnotationRoutingStrategy` is used (see [Distributing the Command Bus](../axon-framework/axon-framework-commands/implementations.md#distributedcommandbus) for more).
 * A `ServiceInstance` filter - This `Predicate` is used to filter out `ServiceInstance`s retrieved through the `DiscoveryClient`. For example, it allows the removal of instances which are known to not handle any command messages. This might be useful if you have several services within the Spring Cloud Discovery Service set up, which you do not ever want to take into account for command handling.
-* `ConsistentHashChangeListener` - Adding a consistent hash change listener provides you the opportunity to perform a specific task if new nodes have been added to the known command handlers set.
+* `ConsistentHashChangeListener` - Adding a consistent hash change listener provides you with the opportunity to perform a specific task if new nodes have been added to the known command handlers set.
 
 > **Differing Command Capabilities per Node**
 >

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -29,7 +29,7 @@ Furthermore, it is the `ServiceInstance` which provides us with the required inf
 > **Spring Cloud's Heartbeat Requirement**
 >
 > When using the `SpringCloudCommandRouter`, make sure your Spring application has heartbeat events enabled.
-> The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstance`s from the `DiscoveryClient` has changed.
+> The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstance`s from the `DiscoveryClient` has been changed.
 > Additionally, it is used to validate whether the command routing capabilities for known nodes has been altered.
 >
 > Thus, if heartbeat events are disabled, your instance will no longer be updated with the current command routing capabilities.
@@ -67,7 +67,7 @@ There are three hard requirements when creating this service and one optional co
 
 1. Local `CommandBus` - This "local segment" is the command bus which dispatches commands into the local JVM. It is thus invoked when the `SpringHttpCommandBusConnector` receives a command from the outside, or if it receives a command which is meant for itself.
 2. `RestOperations` - The service used to POST a command message to another instance. In most situations the `RestTemplate` is used for this.
-3. `Serializer` - The serializer is used to de-/serialize the command messages before they are sent over or when they are received.
+3. `Serializer` - The serializer is used to serialize the command messages before they are sent over and deserialize when they are received.
 4. `Executor` (optional) - The `Executor` is used to handle incoming commands and to dispatch commands. Defaults to a `DirectExecutor` instance.
 
 ## Configuring this Extension
@@ -75,7 +75,7 @@ There are three hard requirements when creating this service and one optional co
 Chances are high that you will be using Spring Boot if you are also using Spring Cloud.
 As configuring goes, this would opt for usage of the `axon-springcloud-spring-boot-starter` dependency to automatically retrieve all required beans.
 In either case, your application should be marked to enable it as a discoverable service through Spring Cloud.
-This can for example be done by annotating the main class with `@EnableDiscoveryClient`. 
+This can, for example, be done by annotating the main class with `@EnableDiscoveryClient`. 
 
 There are still quite a few customizable components.
 For some suggestions, take a look at the following examples:

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -22,7 +22,7 @@ To that end it uses the `DiscoveryClient` and `Registration` from Spring Cloud.
 These are respectively used to gather remote command routing information and maintain local information.
 The most straightforward way to retrieve both is by annotating your application with `@EnableDiscoveryClient`.
 
-The gathering and storage of command routing information revolves around Spring Cloud's `ServiceInstance`s.
+Gathering and storing the command routing information revolves around Spring Cloud's `ServiceInstance`s.
 A `Registration` is just the local `ServiceInstance`, whereas the `DiscoveryClient` provides the API to find remote `ServiceInstance`s.
 Furthermore, it is the `ServiceInstance` which provides us with the required information (e.g. the URI) to retrieve a node's capabilities.
 

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -56,7 +56,7 @@ There are, however, a couple of additional things you can configure for this rou
 >
 > It is not required for all nodes to have the same set of command handlers. 
 > You may use different segments for different command types altogether. 
-> The Distributed Command Bus will always choose a node to dispatch a command to that has support for that specific type of command.
+> The Distributed Command Bus will always choose a node to dispatch a command to the one that has support for that specific type of command.
 
 ## Sending Commands between nodes
 

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -75,7 +75,7 @@ There are three hard requirements when creating this service and one optional co
 Chances are high that you will be using Spring Boot if you are also using Spring Cloud.
 As configuring goes, this would opt for usage of the `axon-springcloud-spring-boot-starter` dependency to automatically retrieve all required beans.
 In either case, your application should be marked to enable it as a discoverable service through Spring Cloud.
-This can for example be done by annotation the main class with `@EnableDiscoveryClient`. 
+This can for example be done by annotating the main class with `@EnableDiscoveryClient`. 
 
 There are quite some customizable components still.
 For some suggestions in that space, take a look at the following examples:

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -72,7 +72,7 @@ There are three hard requirements when creating this service and one optional co
 
 ## Configuring this Extension
 
-Chance are high you will be using Spring Boot if you are also using Spring Cloud.
+Chances are high that you will be using Spring Boot if you are also using Spring Cloud.
 As configuring goes, this would opt for usage of the `axon-springcloud-spring-boot-starter` dependency to automatically retrieve all required beans.
 In either case, your application should be marked to enable it as a discoverable service through Spring Cloud.
 This can for example be done by annotation the main class with `@EnableDiscoveryClient`. 

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -20,7 +20,7 @@ The former is the `CommandRouter` and latter the `CommandBusConnector`, both use
 The `SpringCloudCommandRouter` uses Spring Cloud's discovery mechanism to find the other nodes in the cluster.
 To that end it uses the `DiscoveryClient` and `Registration` from Spring Cloud.
 These are respectively used to gather remote command routing information and maintain local information.
-The most straightforward way to retrieve both is by annotating your application with  `@EnableDiscoveryClient`.
+The most straightforward way to retrieve both is by annotating your application with `@EnableDiscoveryClient`.
 
 The gathering and storage of command routing information revolves around Spring Cloud's `ServiceInstance`s.
 A `Registration` is just the local `ServiceInstance`, whereas the `DiscoveryClient` provides the API to find remote `ServiceInstance`s.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -77,7 +77,7 @@ As configuring goes, this would opt for usage of the `axon-springcloud-spring-bo
 In either case, your application should be marked to enable it as a discoverable service through Spring Cloud.
 This can for example be done by annotating the main class with `@EnableDiscoveryClient`. 
 
-There are quite some customizable components still.
+There are still quite a few customizable components.
 For some suggestions in that space, take a look at the following examples:
 
 {% tabs %}

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -7,7 +7,7 @@ You thus have the choice of which Spring Cloud implementation to use when discov
 An example implementations is the Netflix' [Eureka Discovery/Eureka Server](https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html) combination or HashiCorp's [Consul](https://www.consul.io/use-cases/service-discovery-and-health-checking).
 
 To use the Spring Cloud components from Axon, make sure the `axon-springcloud` module is available on the classpath.
-Easiest would be to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.
+The easiest way is to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.
 
 Giving a description of every Spring Cloud implementation would push this reference guide too far. 
 For information on any of the Spring Cloud implementation options out there, we refer to their respective documentations.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -9,7 +9,7 @@ An example implementations is the Netflix' [Eureka Discovery/Eureka Server](http
 To use the Spring Cloud components from Axon, make sure the `axon-springcloud` module is available on the classpath.
 Easiest would be to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.
 
-Giving a description of every Spring Cloud implementation would push this reference guide to far. 
+Giving a description of every Spring Cloud implementation would push this reference guide too far. 
 For information on any of the Spring Cloud implementation options out there, we refer to their respective documentations.
 
 The Spring Cloud connector setup is a combination of the `SpringCloudCommandRouter` and a `SpringHttpCommandBusConnector`.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -30,7 +30,7 @@ Furthermore, it is the `ServiceInstance` which provides us with the required inf
 >
 > When using the `SpringCloudCommandRouter`, make sure your Spring application has heartbeat events enabled.
 > The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstance`s from the `DiscoveryClient` has changed.
-> On top of that it is used to validate whether the command routing capabilities for known nodes has been altered.
+> Additionally, it is used to validate whether the command routing capabilities for known nodes has been altered.
 >
 > Thus, if heartbeat events are disabled, your instance will no longer be updated with the current command routing capabilities.
 > As such, this will cause issues during command routing.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -3,7 +3,7 @@
 Spring Cloud is an alternative approach to distributing the command bus \(commands\), besides Axon Server as the default.
 
 The Spring Cloud Extension uses the service registration and discovery mechanism described by [Spring Cloud](https://spring.io/projects/spring-cloud) for distributing the command bus. 
-You thus have the choice of Spring Cloud implementation to use when discovering the routes to distribute your commands. 
+You thus have the choice of which Spring Cloud implementation to use when discovering the routes to distribute your commands. 
 An example implementations is the Netflix' [Eureka Discovery/Eureka Server](https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html) combination or HashiCorp's [Consul](https://www.consul.io/use-cases/service-discovery-and-health-checking).
 
 To use the Spring Cloud components from Axon, make sure the `axon-springcloud` module is available on the classpath.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -10,7 +10,7 @@ To use the Spring Cloud components from Axon, make sure the `axon-springcloud` m
 The easiest way is to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.
 
 Giving a description of every Spring Cloud implementation would push this reference guide too far. 
-For information on any of the Spring Cloud implementation options out there, we refer to their respective documentations.
+For information on other Spring Cloud implementation options out there, please refer to their respective documentations.
 
 The Spring Cloud connector setup is a combination of the `SpringCloudCommandRouter` and a `SpringHttpCommandBusConnector`.
 The former is the `CommandRouter` and latter the `CommandBusConnector`, both used by the `DistributedCommandBus` to enable command distribution.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -49,7 +49,7 @@ The `Registration`, `DiscoveryClient` and `CapabilityDiscoveryMode` are arguably
 There are, however, a couple of additional things you can configure for this router, which are the following:
 
 * `RoutingStrategy` - The component in charge of deciding which of the nodes receives the commands consistently. By default a `AnnotationRoutingStrategy` is used (see [Distributing the Command Bus](../axon-framework/axon-framework-commands/implementations.md#distributedcommandbus) for more).
-* A `ServiceInstance` filter - This `Predicate` is used to filter out `ServiceInstance`s retrieved through the `DiscoveryClient`. For example allows the removal of instances which are known to not handle any command messages. This might be useful if you've got several services within the Spring Cloud Discovery Service set up which you do not want to take into account for command handling, ever.
+* A `ServiceInstance` filter - This `Predicate` is used to filter out `ServiceInstance`s retrieved through the `DiscoveryClient`. For example, it allows the removal of instances which are known to not handle any command messages. This might be useful if you have several services within the Spring Cloud Discovery Service set up, which you do not ever want to take into account for command handling.
 * `ConsistentHashChangeListener` - Adding a consistent hash change listener provides you the opportunity to perform a specific task if new nodes have been added to the known command handlers set.
 
 > **Differing Command Capabilities per Node**

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -54,7 +54,7 @@ There are, however, a couple of additional things you can configure for this rou
 
 > **Differing Command Capabilities per Node**
 >
-> It is not required that all nodes have the same set of command handlers. 
+> It is not required for all nodes to have the same set of command handlers. 
 > You may use different segments for different command types altogether. 
 > The Distributed Command Bus will always choose a node to dispatch a command to that has support for that specific type of command.
 

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -68,7 +68,7 @@ There are three hard requirements when creating this service and one optional co
 1. Local `CommandBus` - This "local segment" is the command bus which dispatches commands into the local JVM. It is thus invoked when the `SpringHttpCommandBusConnector` receives a command from the outside, or if it receives a command which is meant for itself.
 2. `RestOperations` - The service used to POST a command message to another instance. In most situations the `RestTemplate` is used for this.
 3. `Serializer` - The serializer is used to de-/serialize the command messages before they are sent over or when they are received.
-4. `Executor` (optional) - The `Executor` used to handle incoming commands and to dispatch commands. Defaults to a `DirectExecutor` instance.
+4. `Executor` (optional) - The `Executor` is used to handle incoming commands and to dispatch commands. Defaults to a `DirectExecutor` instance.
 
 ## Configuring this Extension
 

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -46,7 +46,7 @@ There are decorators present for the `CapabilityDiscoveryMode`, providing two ad
 2. `AcceptAllCommandsDiscoveryMode` - a `CapabilityDiscoveryMode` decorator which regardless of what _this_ instance can handle as commands, state it can handle anything. This decorator comes in handy if the nodes in the system are homogeneous (aka, everybody can handle the same set of commands). 
 
 The `Registration`, `DiscoveryClient` and `CapabilityDiscoveryMode` are arguably the heart of the `SpringCloudCommandRouter`.
-There are however a couple of additional things you can configure for this router, which are the following:
+There are, however, a couple of additional things you can configure for this router, which are the following:
 
 * `RoutingStrategy` - The component in charge of deciding which of the nodes receives the commands consistently. By default a `AnnotationRoutingStrategy` is used (see [Distributing the Command Bus](../axon-framework/axon-framework-commands/implementations.md#distributedcommandbus) for more).
 * A `ServiceInstance` filter - This `Predicate` is used to filter out `ServiceInstance`s retrieved through the `DiscoveryClient`. For example allows the removal of instances which are known to not handle any command messages. This might be useful if you've got several services within the Spring Cloud Discovery Service set up which you do not want to take into account for command handling, ever.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -28,7 +28,7 @@ Furthermore, it is the `ServiceInstance` which provides us with the required inf
 
 > **Spring Cloud's Heartbeat Requirement**
 >
-> When using the `SpringCloudCommandRouter`, make sure that your Spring application has heartbeat events enabled.
+> When using the `SpringCloudCommandRouter`, make sure your Spring application has heartbeat events enabled.
 > The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstance`s from the `DiscoveryClient` has changed.
 > On top of that it is used to validate whether the command routing capabilities for known nodes has been altered.
 >

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -29,7 +29,7 @@ Furthermore, it is the `ServiceInstance` which provides us with the required inf
 > **Spring Cloud's Heartbeat Requirement**
 >
 > When using the `SpringCloudCommandRouter`, make sure that your Spring application has heartbeat events enabled.
-> The heartbeat events published by a Spring Cloud application are the trigger to check if th set of `ServiceInstance`s from the `DiscoveryClient` has changed.
+> The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstance`s from the `DiscoveryClient` has changed.
 > On top of that it is used to validate whether the command routing capabilities for known nodes has been altered.
 >
 > Thus, if heartbeat events are disabled, your instance will no longer be updated with the current command routing capabilities.

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -60,7 +60,7 @@ There are, however, a couple of additional things you can configure for this rou
 
 ## Sending Commands between nodes
 
-The `CommandBusConnector` is in charge to send the commands, based on a given route, from one node to another.
+The `CommandBusConnector` is in charge of sending commands, based on a given route, from one node to another.
 This extension to that end provides the `SpringHttpCommandBusConnector`, which uses plain REST for sending commands.
 
 There are three hard requirements when creating this service and one optional configuration:

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -78,7 +78,7 @@ In either case, your application should be marked to enable it as a discoverable
 This can for example be done by annotating the main class with `@EnableDiscoveryClient`. 
 
 There are still quite a few customizable components.
-For some suggestions in that space, take a look at the following examples:
+For some suggestions, take a look at the following examples:
 
 {% tabs %}
 {% tab title="Custom Bean Configuration" %}

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -33,7 +33,7 @@ Furthermore, it is the `ServiceInstance` which provides us with the required inf
 > Additionally, it is used to validate whether the command routing capabilities for known nodes has been altered.
 >
 > Thus, if heartbeat events are disabled, your instance will no longer be updated with the current command routing capabilities.
-> As such, this will cause issues during command routing.
+> If so, this will cause issues during command routing.
 
 The logic to store the local capabilities and discovering the remote capabilities of a `ServiceInstance` is maintained in the `CapabilityDiscoveryMode`. 
 It is thus the `CapabilityDiscoveryMode` which provides us the means to actually retrieve a `ServiceInstance`'s set of commands it can handle (if any).

--- a/release-notes/axon-framework-extensions.md
+++ b/release-notes/axon-framework-extensions.md
@@ -22,3 +22,15 @@ When using the [Kubernetes](https://spring.io/projects/spring-cloud-kubernetes) 
 
 The `SpringCloudCommandRouter` failed to correctly connect to a Spring Cloud Discovery Service if the node did not contain any Command Handler methods. This undesired behaviour was marked by user "travikk" and made more lenient under [this](https://github.com/AxonFramework/extension-springcloud/issues/1).
 
+### Spring Cloud 4.4
+
+This release has seen a bunch of adjustments towards the Spring Cloud extension, which can be grouped into two categories.
+Firstly, the introduction of the `CapabilityDiscoveryMode` and secondly the automatic process added to this project:
+
+* Introduced GitHub Actions to build, test and push snapshots of the Spring Cloud Extension, as has been marked in pull request [#68](https://github.com/AxonFramework/extension-springcloud/pull/68). 
+* Dependabot was introduced, ensuring all versions will be as up to date as possible.
+* JUnit4 has been removed entirely, in favor of JUnit 5.
+* The `CapabilityDiscoveryMode` mode has been introduced through issue [#23](https://github.com/AxonFramework/extension-springcloud/issues/23).
+  This approach allows for more flexibility when it comes to defining how command routing information should be retrieved and shared.
+
+For a full list of all the changes, please check the [release notes](https://github.com/AxonFramework/extension-springcloud/releases/tag/axon-springcloud-4.4).


### PR DESCRIPTION
Update the Spring Cloud page to better reflect the current status of the [Spring Cloud Extension](https://github.com/AxonFramework/extension-springcloud).
Most noteworthy in this are the removal (deprecation in code) of the [`SpringCloudHttpBackUpCommandRouter`](https://github.com/AxonFramework/extension-springcloud/blob/master/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java) and the introduction of the [`CapabilityDiscoveryMode`](https://github.com/AxonFramework/extension-springcloud/blob/master/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/CapabilityDiscoveryMode.java) in its stead.
Whilst touching this file, I aimed to update its contents entirely, as it was by no means representative of what the extension does as of release 4.4.

If interested, the code adjustments leading to this guide change can be found in issue [#23](https://github.com/AxonFramework/extension-springcloud/issues/23) and pull request [#28](https://github.com/AxonFramework/extension-springcloud/pull/28)
 