### PR TITLE
[#188] Command Bus Infrastructure adjustments 

### DIFF
--- a/axon-framework/axon-framework-commands/command-handlers.md
+++ b/axon-framework/axon-framework-commands/command-handlers.md
@@ -10,6 +10,13 @@ Command Messages can also be [dispatched](command-dispatchers.md) with different
 
 In order for Axon to know which instance of an Aggregate type should handle the Command Message, the property carrying the Aggregate Identifier in the command object **must** be annotated with `@TargetAggregateIdentifier`. The annotation may be placed on either the field or an accessor method \(e.g. a getter\) in the Command object.
 
+> **Routing in a distributed environment**
+> 
+> Regardless of the type of command, as soon as you are distributing your application (through for example Axon Server), it is recommended to specify a routing key on the command. 
+> The `@TargetAggregateIdentifier` doubles as such, but in absence of a field worthy of the annotation, the `@RoutingKey` annotation should be added to ensure the command can be routed.
+> 
+> If neither of these annotations suffices for your use case, a different `RoutingStrategy` can be configured, as is further specified in the [Routing Strategy](infrastructure.md#routing-strategy) section.
+
 Taking the `GiftCard` Aggregate as an example, we can identify two Command Handlers on the Aggregate:
 
 ```java
@@ -83,9 +90,9 @@ If you prefer to use another mechanism for routing commands, the behavior can be
 
 > **Aggregate Creation Command Handlers**
 >
-> When the `@CommandHandler` annotation is placed on an aggregate's constructor, the respective command will create a new instance of that aggregate and add it to the repository. Those commands do not require to target a specific aggregate instance. Therefore, those commands do not require any `@TargetAggregateIdentifier` or `@TargetAggregateVersion` annotations, nor will a custom `CommandTargetResolver` be invoked for these commands.
->
-> However, regardless of the type of command, as soon as you are distributing your application through for example Axon Server, it is highly recommended to specify a routing key on the given message. The `@TargetAggregateIdentifier` doubles as such, but in absence of a field worthy of the annotation, the `@RoutingKey` annotation should be added to ensure the command can be routed. Additionally, a different `RoutingStrategy` can be configured, as is further specified in the [Command Dispatching section.](command-dispatchers.md)
+> When the `@CommandHandler` annotation is placed on an aggregate's constructor, the respective command will create a new instance of that aggregate and add it to the repository. 
+> Those commands do not require to target a specific aggregate instance. 
+> Therefore, those commands do not require any `@TargetAggregateIdentifier` or `@TargetAggregateVersion` annotations, nor will a custom `CommandTargetResolver` be invoked for these commands.
 
 ### Business Logic and State Changes
 

--- a/axon-framework/axon-framework-commands/command-handlers.md
+++ b/axon-framework/axon-framework-commands/command-handlers.md
@@ -92,7 +92,7 @@ If you prefer to use another mechanism for routing commands, the behavior can be
 >
 > When the `@CommandHandler` annotation is placed on an aggregate's constructor, the respective command will create a new instance of that aggregate and add it to the repository. 
 > Those commands do not require to target a specific aggregate instance. 
-> Therefore, those commands do not need either the `@TargetAggregateIdentifier` nor the `@TargetAggregateVersion` annotation.
+> Therefore, those commands need neither the `@TargetAggregateIdentifier` nor the `@TargetAggregateVersion` annotation.
 > Furthermore, a custom `CommandTargetResolver` will not be invoked for these commands.
 
 ### Business Logic and State Changes

--- a/axon-framework/axon-framework-commands/command-handlers.md
+++ b/axon-framework/axon-framework-commands/command-handlers.md
@@ -12,10 +12,10 @@ In order for Axon to know which instance of an Aggregate type should handle the 
 
 > **Routing in a distributed environment**
 > 
-> Regardless of the type of command, as soon as you are distributing your application (through for example Axon Server), it is recommended to specify a routing key on the command. 
-> The `@TargetAggregateIdentifier` doubles as such, but in absence of a field worthy of the annotation, the `@RoutingKey` annotation should be added to ensure the command can be routed.
+> Regardless of the type of command, as soon as you start distributing your application (through Axon Server, for example), it is recommended to specify a routing key on the command. 
+> This is the job of the `@TargetAggregateIdentifier`, but in absence of a field worthy of the annotation, the `@RoutingKey` annotation should be added to ensure the command can be routed.
 > 
-> If neither of these annotations suffices for your use case, a different `RoutingStrategy` can be configured, as is further specified in the [Routing Strategy](infrastructure.md#routing-strategy) section.
+> If neither annotation works for your use case, a different `RoutingStrategy` can be configured, as is explained in the [Routing Strategy](infrastructure.md#routing-strategy) section.
 
 Taking the `GiftCard` Aggregate as an example, we can identify two Command Handlers on the Aggregate:
 
@@ -92,7 +92,8 @@ If you prefer to use another mechanism for routing commands, the behavior can be
 >
 > When the `@CommandHandler` annotation is placed on an aggregate's constructor, the respective command will create a new instance of that aggregate and add it to the repository. 
 > Those commands do not require to target a specific aggregate instance. 
-> Therefore, those commands do not require any `@TargetAggregateIdentifier` or `@TargetAggregateVersion` annotations, nor will a custom `CommandTargetResolver` be invoked for these commands.
+> Therefore, those commands do not need either the `@TargetAggregateIdentifier` nor the `@TargetAggregateVersion` annotation.
+> Furthermore, a custom `CommandTargetResolver` will not be invoked for these commands.
 
 ### Business Logic and State Changes
 

--- a/axon-framework/axon-framework-commands/infrastructure.md
+++ b/axon-framework/axon-framework-commands/infrastructure.md
@@ -589,49 +589,29 @@ public class AxonConfig {
 
 ### DistributedCommandBus
 
-`DistributedCommandBus` is an alternative approach to distributing command bus \(commands\). Each instance of the `DistributedCommandBus` on each JVM is called a "Segment".
+The alternative to the [`AxonServerCommandBus`](#axonservercommandbus) is the `DistributedCommandBus`.
+Each instance of the `DistributedCommandBus` on each JVM is referred to as a "Segment".
 
 ![Structure of the Distributed Command Bus](../../.gitbook/assets/distributed-command-bus.png)
 
-The `DistributedCommandBus` relies on two components: a `CommandBusConnector`, which implements the communication protocol between the JVM's, and the `CommandRouter`, which chooses a destination for each incoming command. This router defines which segment of the `DistributedCommandBus` should be given a \`command, based on a routing key calculated by a routing strategy. Two commands with the same routing key will always be routed to the same segment, as long as there is no change in the number and configuration of the segments. Generally, the identifier of the targeted aggregate is used as a routing key.
+The `DistributedCommandBus` relies on two components: 
 
-Two implementations of the `RoutingStrategy` are provided: the `MetaDataRoutingStrategy`, which uses a metadata property in the command message to find the routing key, and the `AnnotationRoutingStrategy`, which uses the `@TargetAggregateIdentifier` annotation on the Command Messages payload to extract the routing key. Obviously, you can also provide your own implementation.
+ 1. The `CommandBusConnector` - implements the communication protocol between the JVM's to send the command over the wire and to receive the response. 
+ 2. The `CommandRouter` - chooses the destination for each incoming command.
+    It defines which segment of the `DistributedCommandBus` should be given a command, based on a routing key calculated by the [routing strategy](#routing-strategy).
+    
+You can choose different flavors of these components that are available as extension modules.
+Currently, Axon provides two extensions to that end, which are:
 
-By default, the `RoutingStrategy` implementations will throw an exception when no key can be resolved from a command message. This behavior can be altered by providing a `UnresolvedRoutingKeyPolicy` in the constructor of the `MetaDataRoutingStrategy` or `AnnotationRoutingStrategy`. There are three possible policies:
-
-* `ERROR` - the default, and will cause an exception to be thrown when a Routing Key is not available
-* `RANDOM_KEY` - will return a random value when a \`routing key cannot be resolved from the command message.
-
-  This effectively means that those commands will be routed to a random segment of the command bus.
-
-* `STATIC_KEY` - Will return a static key \(being "unresolved"\) for unresolved routing keys.
-
-  This effectively means that all those commands will be routed to the same segment, as long as the configuration of segments does not change.
-
-You can choose different flavor of this components that are available in one of the extension modules:
-
-* [SpringCloud](../../extensions/spring-cloud.md) or 
-* [JGroups](../../extensions/jgroups.md).
+ 1. The [SpringCloud](../../extensions/spring-cloud.md) extension 
+ 2. The [JGroups](../../extensions/jgroups.md) extension
 
 Configuring a distributed command bus can \(mostly\) be done without any modifications in configuration files.
-
-First of all, the starters for one of the Axon distributed command bus modules needs to be included \(e.g. [JGroups](../../extensions/jgroups.md) or [Spring Cloud](../../extensions/spring-cloud.md)\).
-
-Once that is present, a single property needs to be added to the application context, to enable the distributed command bus:
+The most straightforward approach to this is to include the Spring Boot starter dependency of either the Spring Cloud or JGroups extension.
+With that in place, a single property needs to be added to the application context, to enable the `DistributedCommandBus`:
 
 ```text
 axon.distributed.enabled=true
 ```
 
-There is one setting that is independent of the type of connector used:
-
-```text
-axon.distributed.load-factor=100
-```
-
-The load factor of a Distributed Command Bus is defaulted to `100`.
-
-> **The Load Factor Explained**
->
-> The load factor defines the amount of load the instance would carry compared to others. For example, if you have a two machine set up, both with a load factor of 100, both will carry an equal amount of load. Increasing the load factor to 200 on both would still mean that both machines receive the same amount of load. Concluding, the load factor is intended to serve heterogeneous application landscapes with the means to distribute more load to faster machines than to slower machines.
-
+It is recommended to visit the respective extension pages on how to configure JGroups or Spring Cloud for the `DistributedCommandBus`.

--- a/axon-framework/axon-framework-commands/infrastructure.md
+++ b/axon-framework/axon-framework-commands/infrastructure.md
@@ -2,13 +2,13 @@
 
 Command dispatching, as exemplified in the [Dispatching Commands](command-dispatchers.md) page, has a number of advantages. 
 Firstly, it constructs an object that clearly describes the intent of the client. 
-By logging the command, you store both the intent and related data for future reference. 
+By logging the command, you store both the intent and the related data for future reference. 
 Command handling also makes it easy to expose your command processing components to remote clients, via web services for example. 
 
 Testing also becomes a lot easier. 
 You could define test scripts by just defining the starting situation \(given\), command to execute \(when\) and expected results \(then\) by listing a number of events and commands \(see [Testing](../testing/commands-events.md) for more on this\).
 
-The last major advantage is that it is very easy to switch between synchronous and asynchronous as well as local versus distributed command processing.
+The last major advantage is that it is very easy to switch between synchronous and asynchronous, as well as local versus distributed command processing.
 
 This does not mean command dispatching using explicit command objects is the only way to do it. The goal of Axon is not to prescribe a specific way of working, but to support you doing it your way, while providing best practices as the default behavior. It is still possible to use a service layer that you can invoke to execute commands. The method will just need to start a unit of work \(see [Unit of Work](../messaging-concepts/unit-of-work.md)\) and perform a commit or rollback on it when the method is finished.
 
@@ -378,11 +378,11 @@ public DisruptorCommandBus commandBus(TransactionManager txManager, AxonConfigur
 
 ## The Command Bus - Distributed
 
-More often you want multiple instances of command buses in different JVMs to act as one. 
+Often time you would want multiple instances of command buses in different JVMs to act as one. 
 Commands dispatched on one JVM's command bus should be seamlessly transported to a command handler in another JVM while sending back any results.
 That is where the concept of 'distributing the command bus' comes in.
 
-There are a couple of concepts that are configurable, regardless of the type of distribute command bus used:
+There are a couple of concepts that are configurable, regardless of the type of distributed command bus that is being used:
 
 ### Local Segment
 
@@ -391,16 +391,16 @@ All they do is form a "bridge" between command bus implementations on different 
 
 By default, this local segment is the [`SimpleCommandBus`](infrastructure.md#simplecommandbus).
 You can configure the local segment to be any of the other local command buses too, like the [`AsynchronousCommandBus`](infrastructure.md#asynchronouscommandbus) and [`DisruptorCommandBus`](infrastructure.md#disruptorcommandbus).
-How to configure the local segment will be shown in the sections of the implementations
+The details of how to configure the local segment are shown in the implementation sections.
 
 ### Load Factor
 
 The load factor defines the amount of load an Axon application would carry compared to other instances.
-For example, if you have a two machine set up, both with a load factor of 100, both will carry an equal amount of load.
+For example, if you have a two machine set up, each with a load factor of 100, they will both carry an equal amount of load.
 
 Increasing the load factor to 200 on both would still mean that both machines receive the same amount of load.
-This points out that the load factor will only change load amongst systems if the values are in equal.
-Doing so would make sense in a heterogeneous application landscape, where for the faster machines should deal with a bigger portion of command handling than the slower machines.
+This points out that the load factor will only change the load amongst systems if the values are not equal.
+Doing so would make sense in a heterogeneous application landscape, where the faster machines should deal with a bigger portion of command handling than the slower machines.
 
 The default load factor set for the distributed `CommandBus` implementations is 100.
 The configuration changes slightly per distributed implementation and as such will be covered in those sections.
@@ -409,23 +409,24 @@ The configuration changes slightly per distributed implementation and as such wi
 
 Commands should be [routed consistently](../../architecture-overview/README.md#explicit-messaging) to the same application, especially those targeted towards a specific Aggregate.
 This ensures a single instance is in charge of the targeted aggregate, resolving the concurrent access issue and allowing for optimization like caching to work as designed.
-To component dealing with the consistent routing in an Axon application, is the `RoutingStrategy`.
+The component dealing with the consistent routing in an Axon application, is the `RoutingStrategy`.
 
 The `RoutingStrategy` receives a `CommandMessage` and based on the message returns the routing key to use.
 Two commands with the same routing key will **always** be routed to the same segment, as long as there is no topology change in the distributed set-up.
 
-At the moment, there are five implementations of the `RoutingStrategy`, where three of these are intended to be a fallback solution in case the routing key cannot be resolved:
+At the moment, there are five implementations of the `RoutingStrategy`. 
+Three of these are intended to be a fallback solution in case the routing key cannot be resolved:
 
- 1. The `AnnotationRoutingStrategy` - the **default** routing strategy expecting the `TargetAggregateIdentifier` or `RoutingKey` annotation to be present on a field inside the command class. 
+ 1. The `AnnotationRoutingStrategy` - the **default** routing strategy expects the `TargetAggregateIdentifier` or `RoutingKey` annotation to be present on a field inside the command class. 
     The annotated field or getter is searched, and the contents will be returned as the routing key for that command.
- 2. The `MetaDataRoutingStrategy` - uses a property defined during creation of this strategy to fetch the routing key from the `CommandMessage` its `MetaData`.
+ 2. The `MetaDataRoutingStrategy` - uses a property defined during creation of this strategy to fetch the routing key from the `CommandMessage`'s `MetaData`.
  3. The `ERROR` `UnresolvedRoutingKeyPolicy` - the **default fallback** that will cause an exception to be thrown when the routing key cannot be resolved from the given `CommandMessage`.
  4. The `RANDOM_KEY` `UnresolvedRoutingKeyPolicy` - will return a random value when a routing key cannot be resolved from the `CommandMessage`. 
-    This effectively means that those commands will be routed to a random segment of the command bus.
+    This means that those commands will be routed to a random segment of the command bus.
  5. The `STATIC_KEY` `UnresolvedRoutingKeyPolicy` - will return a static key \(named "unresolved"\) for unresolved routing keys. 
-    This effectively means that all those commands will be routed to the same segment, as long as the configuration of segments does not change.
+    This policy routes all commands to the same segment, as long as the configuration of segments does not change.
 
-The `AnnotationRoutingStrategy`  and `MetaDataRoutingStrategy` are considered the full implementations to configure.
+The `AnnotationRoutingStrategy` and `MetaDataRoutingStrategy` are considered the full implementations to configure.
 The `ERROR`, `RANDOM_KEY` and `STATIC_KEY` are _fallback routing strategies_ that should be configured on the annotation or meta-data implementations.
 To get a grasp how these are constructed, consider the following sample:
 
@@ -458,7 +459,7 @@ public RoutingStrategy routingStrategy() {
 {% endtab %}
 {% endtabs %}
 
-Of course a custom implementation of the `RoutingStrategy` can also be provided when necessary
+Of course, a custom implementation of the `RoutingStrategy` can also be provided when necessary.
 When we need to deviate from the default `AnnotationRoutingStrategy`, we should configure it like so: 
 
 {% tabs %}
@@ -466,8 +467,8 @@ When we need to deviate from the default `AnnotationRoutingStrategy`, we should 
 ```java
 public class AxonConfig {
     // ...  
-    public void configureRoutingStrategy(Configurer configurer, RoutingStrategy routingStrategy) {
-        configurer.registerComponent(RoutingStrategy.class, config -> routingStrategy);
+    public void configureRoutingStrategy(Configurer configurer, YourRoutingStrategy yourRoutingStrategy) {
+        configurer.registerComponent(RoutingStrategy.class, config -> yourRoutingStrategy);
     }
 }
 ```
@@ -489,8 +490,8 @@ public class AxonConfig {
 
 ### AxonServerCommandBus
 
-The `AxonServerCommandBus` is the _default_ distributed `CommandBus` implementation set by the framework.
-It connects to [AxonServer](../../axon-server-introduction.md) to submit and receive commands with.
+The `AxonServerCommandBus` is the _default_ distributed `CommandBus` implementation that is set by the framework.
+It connects to [AxonServer](../../axon-server-introduction.md), with which it can send and receive commands.
 
 As it is the default, configuring it is relatively straightforward:
 
@@ -498,17 +499,33 @@ As it is the default, configuring it is relatively straightforward:
 {% tab title="Axon Configuration API" %}
 Declare dependencies:
 ```text
-<!--somewhere in the POM file-->
-<dependency>
-    <groupId>org.axonframework</groupId>
-    <artifactId>axon-server-connector</artifactId>
-    <version>${axon.version}</version>
-</dependency>
-<dependency>
-    <groupId>org.axonframework</groupId>
-    <artifactId>axon-configuration</artifactId>
-    <version>${axon.version}</version>
-</dependency>
+<!-- somewhere in the POM file... -->
+<dependencyManagement>
+    <!-- amongst the dependencies... -->
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-bom</artifactId>
+            <version>${version.axon}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+    <!-- ... -->
+</dependencyManagement>
+<!-- ... -->
+<dependencies>
+    <!-- amongst the dependencies... -->
+    <dependency>
+        <groupId>org.axonframework</groupId>
+        <artifactId>axon-server-connector</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.axonframework</groupId>
+        <artifactId>axon-configuration</artifactId>
+    </dependency>
+    <!-- ... -->
+</dependencies>
 ```
 
 Configure your application:
@@ -519,7 +536,7 @@ Configurer configurer = DefaultConfigurer.defaultConfiguration();
 {% endtab %}
 
 {% tab title="Spring Boot AutoConfiguration" %}
-By simply declaring the `axon-spring-boot-starter` dependency, Axon will automatically configure the `AxonServerCommandBus`:
+By simply including the `axon-spring-boot-starter` dependency, Axon will automatically configure the `AxonServerCommandBus`:
 
 ```text
 <!--somewhere in the POM file-->
@@ -540,13 +557,13 @@ By simply declaring the `axon-spring-boot-starter` dependency, Axon will automat
 > 1. By excluding the `axon-server-connector` dependency.
 > 2. By setting `axon.server.enabled` to `false` when Spring Boot is used.
 >
-> When doing either of these, Axon will fallback to the not distributed [`SimpleCommandBus`](infrastructure.md#simplecommandbus), unless configured otherwise.
+> When doing any of these, Axon will fallback to the **un**distributed [`SimpleCommandBus`](infrastructure.md#simplecommandbus), unless configured otherwise.
 
 #### Local Segment and Load Factor Configuration
 
 The [load factor](#load-factor) for the `AxonServerCommandBus` is defined through the `CommandLoadFactorProvider`.
-This interface allows us to define a different load factor per command message.
-This might proof useful if some commands should be targeted towards more often to one instance in favour of the other.
+This interface allows us to distinguish between commands to, for example, use a different load factor per command message.
+This might be useful if some commands are routed more often towards one instance in favour of the other.
 
 The following should be done to configure a custom [local segment](#local-segment) and/or load factor:
 

--- a/axon-framework/axon-framework-commands/infrastructure.md
+++ b/axon-framework/axon-framework-commands/infrastructure.md
@@ -1,10 +1,19 @@
 # Infrastructure
 
-Command dispatching, as exemplified in the [Dispatching Commands](command-dispatchers.md) page, has a number of advantages. First of all, there is a single object that clearly describes the intent of the client. By logging the command, you store both the intent and related data for future reference. Command handling also makes it easy to expose your command processing components to remote clients, via web services for example. Testing also becomes a lot easier. You could define test scripts by just defining the starting situation \(given\), command to execute \(when\) and expected results \(then\) by listing a number of events and commands \(see [Testing](../testing/) for more on this\). The last major advantage is that it is very easy to switch between synchronous and asynchronous as well as local versus distributed command processing.
+Command dispatching, as exemplified in the [Dispatching Commands](command-dispatchers.md) page, has a number of advantages. 
+Firstly, it constructs an object that clearly describes the intent of the client. 
+By logging the command, you store both the intent and related data for future reference. 
+Command handling also makes it easy to expose your command processing components to remote clients, via web services for example. 
+
+Testing also becomes a lot easier. 
+You could define test scripts by just defining the starting situation \(given\), command to execute \(when\) and expected results \(then\) by listing a number of events and commands \(see [Testing](../testing/commands-events.md) for more on this\).
+
+The last major advantage is that it is very easy to switch between synchronous and asynchronous as well as local versus distributed command processing.
 
 This does not mean command dispatching using explicit command objects is the only way to do it. The goal of Axon is not to prescribe a specific way of working, but to support you doing it your way, while providing best practices as the default behavior. It is still possible to use a service layer that you can invoke to execute commands. The method will just need to start a unit of work \(see [Unit of Work](../messaging-concepts/unit-of-work.md)\) and perform a commit or rollback on it when the method is finished.
 
 The next sections provide an overview of the tasks related to setting up a command dispatching infrastructure with the Axon Framework.
+The API-friendlier [`CommandGateway`](#the-command-gateway) is mentioned, as well as the `CommandBus` in both a [local](#the-command-bus---local) and [distributed](#the-command-bus---distributed) environment. 
 
 ## The Command Gateway
 
@@ -22,7 +31,7 @@ Both your custom Command Gateway and the one provided by Axon need to at least b
 
 The `RetryScheduler` is capable of scheduling retries when command execution has failed. When a command fails due to an exception that is explicitly non-transient, no retries are done at all. Note that the retry scheduler is only invoked when a command fails due to a `RuntimeException`. Checked exceptions are regarded as a "business exception" and will never trigger a retry.
 
-Currently two implementations exist:
+Currently, two implementations exist:
 
 1. The `IntervalRetryScheduler` will retry a given command at set intervals until it succeeds,
 

--- a/axon-framework/axon-framework-commands/infrastructure.md
+++ b/axon-framework/axon-framework-commands/infrastructure.md
@@ -378,7 +378,7 @@ public DisruptorCommandBus commandBus(TransactionManager txManager, AxonConfigur
 
 ## The Command Bus - Distributed
 
-Often time you would want multiple instances of command buses in different JVMs to act as one. 
+Oftentimes you would want multiple instances of command buses in different JVMs to act as one. 
 Commands dispatched on one JVM's command bus should be seamlessly transported to a command handler in another JVM while sending back any results.
 That is where the concept of 'distributing the command bus' comes in.
 
@@ -409,13 +409,13 @@ The configuration changes slightly per distributed implementation and as such wi
 
 Commands should be [routed consistently](../../architecture-overview/README.md#explicit-messaging) to the same application, especially those targeted towards a specific Aggregate.
 This ensures a single instance is in charge of the targeted aggregate, resolving the concurrent access issue and allowing for optimization like caching to work as designed.
-The component dealing with the consistent routing in an Axon application, is the `RoutingStrategy`.
+The component dealing with the consistent routing in an Axon application is the `RoutingStrategy`.
 
 The `RoutingStrategy` receives a `CommandMessage` and based on the message returns the routing key to use.
 Two commands with the same routing key will **always** be routed to the same segment, as long as there is no topology change in the distributed set-up.
 
 At the moment, there are five implementations of the `RoutingStrategy`. 
-Three of these are intended to be a fallback solution in case the routing key cannot be resolved:
+Three of these are intended to be fallback solutions, in case the routing key cannot be resolved:
 
  1. The `AnnotationRoutingStrategy` - the **default** routing strategy expects the `TargetAggregateIdentifier` or `RoutingKey` annotation to be present on a field inside the command class. 
     The annotated field or getter is searched, and the contents will be returned as the routing key for that command.

--- a/axon-framework/axon-framework-commands/infrastructure.md
+++ b/axon-framework/axon-framework-commands/infrastructure.md
@@ -149,60 +149,11 @@ CommandGatewayFactory factory = CommandGatewayFactory.builder()
 MyGateway myGateway = factory.createGateway(MyGateway.class);
 ```
 
-## The Command Bus
+## The Command Bus - Local
 
-The Command Bus is the mechanism that dispatches commands to their respective command handlers within an Axon application. 
-Suggestions on how to use the `CommandBus` can be found [here](command-dispatchers.md#the-command-bus). Several flavors of the command bus, with differing characteristics, exist within the framework:
-
-### AxonServerCommandBus
-
-Axon provides a command bus out of the box, the `AxonServerCommandBus`. It connects to the [AxonIQ AxonServer Server](../../axon-server-introduction.md) to submit and receive Commands.
-
-`AxonServerCommandBus` is a [distributed command bus](command-dispatchers.md#the-command-bus). It uses a [`SimpleCommandBus`](infrastructure.md) to handle incoming commands on different JVM's by default.
-
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-Declare dependencies:
-
-```text
-<!--somewhere in the POM file-->
-<dependency>
-    <groupId>org.axonframework</groupId>
-    <artifactId>axon-server-connector</artifactId>
-    <version>${axon.version}</version>
-</dependency>
-<dependency>
-    <groupId>org.axonframework</groupId>
-    <artifactId>axon-configuration</artifactId>
-    <version>${axon.version}</version>
-</dependency>
-```
-
-Configure your application:
-
-```java
-// Returns a Configurer instance with default components configured. `AxonServerCommandBus` is configured as Command Bus by default.
-Configurer configurer = DefaultConfigurer.defaultConfiguration();
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-By simply declaring dependency to `axon-spring-boot-starter`, Axon will automatically configure the Axon Server Command Bus:
-
-```text
-<!--somewhere in the POM file-->
-<dependency>
-    <groupId>org.axonframework</groupId>
-    <artifactId>axon-spring-boot-starter</artifactId>
-    <version>${axon.version}</version>
-</dependency>
-```
-
-> **Excluding the Axon Server Connector**
->
-> If you exclude `axon-server-connector` dependency you will fallback to 'non-axon-server' command bus options, the `SimpleCommandBus` \(see [below](infrastructure.md)\).
-{% endtab %}
-{% endtabs %}
+The local command bus is the mechanism that dispatches commands to their respective command handlers within an Axon application. 
+Suggestions on how to use the `CommandBus` can be found [here](command-dispatchers.md#the-command-bus). 
+Several flavors of the command bus, with differing characteristics, exist within the framework.
 
 ### SimpleCommandBus
 
@@ -215,8 +166,14 @@ Since all command processing is done in the same thread, this implementation is 
 {% tabs %}
 {% tab title="Axon Configuration API" %}
 ```java
-Configurer configurer = DefaultConfigurer.defaultConfiguration()
-            .configureCommandBus(c -> SimpleCommandBus.builder().transactionManager(c.getComponent(TransactionManager.class)).messageMonitor(c.messageMonitor(SimpleCommandBus.class, "commandBus")).build());
+Configurer configurer =
+    DefaultConfigurer.defaultConfiguration()
+                     .configureCommandBus(
+                        c -> SimpleCommandBus.builder()
+                                             .transactionManager(c.getComponent(TransactionManager.class))
+                                             .messageMonitor(c.messageMonitor(SimpleCommandBus.class, "commandBus"))
+                                             .build()
+                     );
 ```
 {% endtab %}
 
@@ -235,10 +192,6 @@ public SimpleCommandBus commandBus(TransactionManager txManager, AxonConfigurati
     return commandBus;
 }
 ```
-
-> **Excluding the Axon Server Connector**
->
-> If you exclude the `axon-server-connector` dependency from the `axon-spring-boot-starter` dependency, the `SimpleCommandBus` will be auto-configured for you.
 {% endtab %}
 {% endtabs %}
 

--- a/extensions/jgroups.md
+++ b/extensions/jgroups.md
@@ -2,7 +2,9 @@
 
 JGroups is an alternative approach to distributing command bus \(commands\) besides Axon Server.
 
-The `JGroupsConnector` uses \(as the name already gives away\) [JGroups](http://www.jgroups.org/) as the underlying discovery and dispatching mechanism. Describing the feature set of JGroups is a bit too much for this reference guide, so please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more information.
+The `JGroupsConnector` uses \(as the name already gives away\) [JGroups](http://www.jgroups.org/) as the underlying discovery and dispatching mechanism. 
+Describing the features of JGroups is beyond the scope this reference guide
+Please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more information.
 
 To use the JGroups components from Axon, make sure the `axon-jgroups` module is available on the classpath through the preferred dependency management system.
 When combined with Spring Boot, the `axon-jgroups-spring-boot-starter` dependency can be included to enable auto-configuration.

--- a/extensions/jgroups.md
+++ b/extensions/jgroups.md
@@ -2,7 +2,7 @@
 
 JGroups is an alternative approach to distributing command bus \(commands\) besides Axon Server.
 
-The `JGroupsConnector` uses \(as the name already gives away\) [JGroups](http://www.jgroups.org/) as the underlying discovery and dispatching mechanism. Describing the feature set of JGroups is a bit too much for this reference guide, so please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more details.
+The `JGroupsConnector` uses \(as the name already gives away\) [JGroups](http://www.jgroups.org/) as the underlying discovery and dispatching mechanism. Describing the feature set of JGroups is a bit too much for this reference guide, so please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more information.
 
 To use the JGroups components from Axon, make sure the `axon-jgroups` module is available on the classpath through the preferred dependency management system.
 When combined with Spring Boot, the `axon-jgroups-spring-boot-starter` dependency can be included to enable auto-configuration.

--- a/extensions/jgroups.md
+++ b/extensions/jgroups.md
@@ -1,10 +1,11 @@
 # JGroups
 
-JGroups is an alternative approach to distributing command bus \(commands\), besides Axon Server which is the default.
+JGroups is an alternative approach to distributing command bus \(commands\) besides Axon Server.
 
-The `JGroupsConnector` uses \(as the name already gives away\) JGroups as the underlying discovery and dispatching mechanism. Describing the feature set of JGroups is a bit too much for this reference guide, so please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more details.
+The `JGroupsConnector` uses \(as the name already gives away\) [JGroups](http://www.jgroups.org/) as the underlying discovery and dispatching mechanism. Describing the feature set of JGroups is a bit too much for this reference guide, so please refer to the [JGroups User Guide](http://www.jgroups.org/ug.html) for more details.
 
-To use the Spring JGroups components from Axon, make sure the `axon-jgroups` module is available on the classpath.
+To use the JGroups components from Axon, make sure the `axon-jgroups` module is available on the classpath through the preferred dependency management system.
+When combined with Spring Boot, the `axon-jgroups-spring-boot-starter` dependency can be included to enable auto-configuration.
 
 Since JGroups handles both discovery of nodes and the communication between them, the `JGroupsConnector` acts as both a `CommandBusConnector` and a `CommandRouter`.
 
@@ -58,13 +59,22 @@ connector.connect();
 >
 > Note that it is not required that all segments have command handlers for the same type of commands. You may use different segments for different command types altogether. The distributed command bus will always choose a node to dispatch a command to that has support for that specific type of command.
 
-## Configuration in Spring Boot
+## Configuration in Spring (Boot)
 
-If you use Spring, you may want to consider using the `JGroupsConnectorFactoryBean`. It automatically connects the connector when the `ApplicationContext` is started, and does a proper disconnect when the `ApplicationContext` is shut down. Furthermore, it uses sensible defaults for a testing environment \(but should not be considered production ready\) and autowiring for the configuration.
+If you use Spring, you may want to consider using the `JGroupsConnectorFactoryBean`. 
+It automatically connects the connector when the `ApplicationContext` is started, and does a proper disconnect when the `ApplicationContext` is shut down. 
+Furthermore, it uses sensible defaults for a testing environment \(but should not be considered production ready\) and autowiring for the configuration.
+
+If Spring Boot is used, the configuration can be further simplified by including the `axon-jgroups-spring-boot-starter` dependency. 
 
 The settings for the JGroups connector are all prefixed with `axon.distributed.jgroups`.
 
 ```text
+# enables Axon to construct the DistributedCommandBus
+axon.distributed.enabled=true
+# defines the load factor used for this segment. Defaults to 100
+axon.distributed.load-factor=100
+
 # the address to bind this instance to. By default, it attempts to find the Global IP address
 axon.distributed.jgroups.bind-addr=GLOBAL
 # the port to bind the local instance to

--- a/extensions/spring-cloud.md
+++ b/extensions/spring-cloud.md
@@ -151,6 +151,8 @@ public class MyApplication {
 ```properties
 # Required to enabled the DistributedCommandBus
 axon.distributed.enabled=true
+# Defines the load factor used for this segment. Defaults to 100
+axon.distributed.load-factor=100
 # Defines the CapabilityDiscoveryMode used. Defaults to REST
 axon.distributed.spring-cloud.mode=rest
 # Defines the endpoint used to retrieve member capabilities from. Defaults to "/member-capabilities"


### PR DESCRIPTION
The `CommandBus` infrastructure page has been given a thorough adjustment in this pull request.
The main driver for starting this is issue #188, which points out that the `RoutingStrategy` currently does not have a dedicated section wherein it is described.

To accompany a good spot for the `RoutingStrategy` within the infrastructure page, several portions have been moved around and added.
These can be summarized as follows:

- Renamed sections, to construct three main sections, for the `CommandGateway` (unchanged), a local `CommandBus` and a distributed `CommandBus`
- Changed the introduction sections of the main page, the local and distributed `CommandBus` sections
- Removed the mention of the `AxonServerCommandBus` in the local section
- Add a "Local Segment" section to the "Distributed Command Bus" section, to provide more guidance on what the local segment is
- Add a "Load Factor" section to the "Distributed Command Bus" section, to provide more guidance on what the load factor is
- Introduce the "Routing Strategy" section (as mentioned in #188), allowing a linkable portion with additional samples
- Move and improve the `AxonServerCommandBus` section to the distributed command bus section
- Adjust the `DistributedCommandBus` section to refer to the aforementioned section and the extension which carry the actual configuration specifics
- Refer to the Routing Strategy section when the `TargetAggregateIdentifier` and `RoutingKey` annotations are first described
- Adjust the JGroups Extension section to be in line with the above changes
- Adjust the Spring Cloud Extension section to be in line with the above changes

Through the entire process, this PR resolves #188.