### PR TITLE
[#152] Update Supported Parameters Page

### DIFF
--- a/axon-framework/events/event-handlers.md
+++ b/axon-framework/events/event-handlers.md
@@ -4,14 +4,14 @@ An _Event Handler_ is a method that is capable of handling an `EventMessage`.
 As such, the method will react to the occurrences within an application.
 
 In Axon, an _object_ may declare several event handlers by annotating them with `@EventHandler`.
-This _object_ is most often referred to as an _Event Handling Component_, or sometimes an Event Handler too.
+This _object_ is most often referred to as an _Event Handling Component_, or simply an Event Handler.
 When drafting an `@EventHandler` annotated method, the declared parameters of the method define which events it will receive.
 
 Arguably the most important parameter of an event handler is the first parameter which refers to the payload of an `EventMessage`.
 If the event handler does not need access to the payload of the message, you can specify the expected payload type on the `@EventHandler` annotation.
 
 Do not configure the payload type on the annotation if you want the payload to be passed as a parameter.
-For an exhaustive list of all parameters, we refer to [this](../messaging-concepts/supported-parameters-annotated-handlers.md#supported-parameters-for-event-handlers) section.
+For a complete list of all parameters, we refer to [this](../messaging-concepts/supported-parameters-annotated-handlers.md#supported-parameters-for-event-handlers) section.
 
 In all circumstances, at most one event handler method is invoked per listener instance.
 Axon will search for the most specific method to invoke, using the following rules:

--- a/axon-framework/messaging-concepts/supported-parameters-annotated-handlers.md
+++ b/axon-framework/messaging-concepts/supported-parameters-annotated-handlers.md
@@ -1,74 +1,116 @@
 # Supported Parameters for Annotated Handlers
 
-This chapter provides an exhaustive list of all the possible parameters for annotated message handling functions. The parameters for any message handling function are resolved through an Axon Framework internal mechanism, called the `ParameterResolver`.
+This chapter provides an exhaustive list of all the possible parameters for annotated message handling functions. 
+The framework resolves the parameters for any message handling function through an internal mechanism, called the `ParameterResolver`.
+The `ParameterResolver`, built by a `ParameterResolverFactory`, is in charge of inserting the parameters for the command, event and query handlers.
 
-The set of `ParameterResolver`s can be extended if custom \(or not yet\) supported parameters should be injected in to your annotated handlers. For more specifics on configuring custom `ParameterResolver`s we suggest reading [this](../../appendices/message-handler-tuning/parameter-resolvers.md) section.
+The set of `ParameterResolver`s can be extended if custom \(or not yet\) supported parameters should be injected in to your annotated handlers.
+You can configure additional `ParameterResolver`s by implementing the `ParameterResolverFactory` interface and configuring the new implementation.
+For more specifics on configuring custom `ParameterResolver`s we suggest reading [this](../../appendices/message-handler-tuning/parameter-resolvers.md) section.
 
 ## Supported Parameters for Command Handlers
 
 By default, `@CommandHandler` annotated methods allow the following parameter types:
 
-* The first parameter is the payload of the command message.
-
+* The first parameter is always the payload of the command message.
   It may also be of type `Message` or `CommandMessage`, if the `@CommandHandler` annotation explicitly defined the name of the command the handler can process.
-
   By default, a command name is the fully qualified class name of the command its payload.
 
-* Parameters annotated with `@MetaDataValue` will resolve to the metadata value with the key as indicated on the annotation.
+* Parameters of type `MetaData` will have the entire metadata of a `CommandMessage` injected.
 
+* Parameters annotated with `@MetaDataValue` will resolve the metadata value with the key as indicated on the annotation.
   If `required` is `false` \(default\), `null` is passed when the metadata value is not present.
-
   If `required` is `true`, the resolver will not match and prevent the method from being invoked when the metadata value is not present.
 
-* Parameters of type `MetaData` will have the entire `MetaData` of a `CommandMessage` injected.
-* Parameters of type `UnitOfWork` get the current unit of work injected. This allows command handlers to register actions to be performed at specific stages of the Unit of Work, or gain access to the resources registered with it.
 * Parameters of type `Message`, or `CommandMessage` will get the complete message, with both the payload and the metadata.
+  Resolving the entire `Message` is helpful if a method needs several metadata fields or other properties of the message.
 
-  This is useful if a method needs several metadata fields, or other properties of the wrapping Message.
+* Parameters of type `UnitOfWork` get the current [unit of work](unit-of-work.md) injected.
+  The `UnitOfWork` allows command handlers to register actions to be performed at specific stages of the unit of work or gain access to the resources registered with it.
 
-* A parameter of type `String` annotated with `@MessageIdentifier` will resolve the identifier of the `CommandMessage` being handled
+* A parameter of type `String` annotated with `@MessageIdentifier` will resolve the identifier of the handled `CommandMessage`.
+
 * Parameters of type `ConflictResolver` will resolve the configured `ConflictResolver` instance.
-
   See the [Conflict Resolution](../axon-framework-commands/modeling/conflict-resolution.md) section for specifics on this topic.
 
 * Parameters of type `InterceptorChain` will resolve the chain of `MessageHandlerInterceptor`s for a `CommandMessage`.
+  You should use this feature in conjunction with a `@CommandHandlerInterceptor` annotated method.
+  For more specifics on this it is recommended to read [this](message-intercepting.md#commandhandlerinterceptor-annotation) section.
 
-  This feature should be used in conjunction with a `@CommandHandlerInterceptor` annotated method.
+* The parameter resolvers can resolve a `ScopeDescriptor` too.
+  The scope descriptor is helpful when [scheduling a deadline](../deadlines/README.md) through the `DeadlineManager`.
+  Note that the `ScopeDescriptor` only makes sense from within the scope of an Aggregate or Saga.
 
-  For more specifics on this it is recommend to read [this](message-intercepting.md#commandhandlerinterceptor-annotation) section.
+* If the application runs in a Spring environment, any Spring Bean can be resolved.
+  To that end, we should annotate the desired Spring bean with `@Autowired`.
+  We can extend the annotation with `@Qualifier` if a specific version of the bean should be wired.
 
-* If the application is run in a Spring environment, any Spring Bean can be resolved. 
-  
-> If Spring beans are resolved for message handling methods `@Autowired` annotation should be used to get the revamped solution. 
-> 
-> The `@Qualifier` annotation can be used in conjunction with this to further specify which Bean should be resolved.
+## Supported Parameters for Event Handlers
 
-* A parameter of type `ScopeDescriptor` can be resolved. This can be used when scheduling a deadline through the `DeadlineManager`. Note that the `ScopeDescriptor` only makes sense from within the scope of an Aggregate or Saga.
+By default, `@EventHandler` annotated methods allow the following parameter types:
+
+* The first parameter is the payload of the event message.
+  If the event handler does not need access to the payload of the message, you can specify the expected payload type on the `@EventHandler` annotation.
+  Do not configure the payload type on the annotation if you want the payload passed as a parameter.
+
+* Parameters of type `MetaData` will have the entire metadata of an `EventMessage` injected.
+
+* Parameters annotated with `@MetaDataValue` will resolve the metadata value with the key as indicated on the annotation.
+  If `required` is `false` \(default\), `null` is passed when the metadata value is not present.
+  If `required` is `true`, the resolver will not match and prevent the method from being invoked when the metadata value is not present.
+
+* We can resolve the `EventMessage` in its entirety as well.
+  If the first parameter is of type message, it effectively matches an event of any type, even if generic parameters suggest otherwise.
+  Due to type erasure, Axon cannot detect what parameter the implementation expects.
+  It is best to declare a parameter of the payload type in such a case, followed by a parameter of type message.
+
+* Parameters of type `UnitOfWork` get the current [unit of work](unit-of-work.md) injected.
+  The `UnitOfWork` allows event handlers to register actions to be performed at specific stages of the unit of work or gain access to the resources registered with it.
+
+* A parameter of type `String` annotated with `@MessageIdentifier` will resolve the identifier of the handled `EventMessage`.
+
+* Parameters annotated with `@Timestamp` and of type `java.time.Instant` \(or `java.time.temporal.Temporal`\) will resolve to the timestamp of the `EventMessage`.
+  The resolved timestamp is the time at which the event was generated.
+
+* Parameters annotated with `@SequenceNumber` and of type `java.lang.Long` or `long` will resolve to the `sequenceNumber` of a `DomainEventMessage`.
+  This parameter provides the order in which the event was generated (within the aggregate scope it originated from).
+  It is important to note that `DomainEventMessage` **can only** originate from an Aggregate.
+  Hence, events that have been published directly on the `EventBus`/`EventGateway` are _not_ implementations of the `DomainEventMessage`. As such, they will not resolve a sequence number.
+
+* Parameters of type `TrackingToken` will have the current [token](../events/event-processors/streaming.md#tracking-tokens) related to the processed event injected.
+  Note that this will only work for `StreamingEventProcessor` instances, as otherwise, there is no token attached to the events.
+
+* Parameters annotated with `@SourceId` and of type `java.lang.String` will resolve to the `aggregateIdentifier` of a `DomainEventMessage`.
+  This parameter provides the identifier of the aggregate from which the event originates.
+  It is important to note that `DomainEventMessage` **can only** originate from an Aggregate.
+  Hence, events that have been published directly on the `EventBus`/`EventGateway` are _not_ implementations of the `DomainEventMessage`. As such, they will not resolve a source id.
+
+* If the application runs in a Spring environment, any Spring Bean can be resolved.
+  To that end, we should annotate the desired Spring bean with `@Autowired`.
+  We can extend the annotation with `@Qualifier` if a specific version of the bean should be wired.
 
 ## Supported Parameters for Query Handlers
 
 By default, `@QueryHandler` annotated methods allow the following parameter types:
 
-* The first parameter is the payload of the query message.
-
+* The first parameter is always the payload of the query message.
   It may also be of type `Message` or `QueryMessage`, if the `@QueryHandler` annotation explicitly defined the name of the query the handler can process.
-
   By default, a query name is the fully qualified class name of the query its payload.
 
-* Parameters annotated with `@MetaDataValue` will resolve to the metadata value with the key as indicated on the annotation.
+* Parameters of type `MetaData` will have the entire metadata of a `QueryMessage` injected.
 
+* Parameters annotated with `@MetaDataValue` will resolve the metadata value with the key as indicated on the annotation.
   If `required` is `false` \(default\), `null` is passed when the metadata value is not present.
-
   If `required` is `true`, the resolver will not match and prevent the method from being invoked when the metadata value is not present.
 
-* Parameters of type `MetaData` will have the entire metadata of a `QueryMessage` injected.
-* Parameters of type `UnitOfWork` get the current unit of work injected. This allows query handlers to register actions to be performed at specific stages of the unit of work, or gain access to the resources registered with it.
 * Parameters of type `Message`, or `QueryMessage` will get the complete message, with both the payload and the metadata.
+  Resolving the entire `Message` is helpful if a method needs several metadata fields or other properties of the message.
 
-  This is useful if a method needs several meta data fields, or other properties of the wrapping message.
+* Parameters of type `UnitOfWork` get the current [unit of work](unit-of-work.md) injected.
+  The `UnitOfWork` allows query handlers to register actions to be performed at specific stages of the unit of work or gain access to the resources registered with it.
 
-* A parameter of type `String` annotated with `@MessageIdentifier` will resolve the identifier of the `QueryMessage` being handled
+* A parameter of type `String` annotated with `@MessageIdentifier` will resolve the identifier of the handled `CommandMessage`.
 
-> If Spring beans are resolved for message handling methods `@Autowired` annotation should be used to get the revamped solution.
-> 
-> Note that the `@Qualifier` annotation can be used in conjunction with this to further specify which Bean should be resolved.
+* If the application runs in a Spring environment, any Spring Bean can be resolved.
+  To that end, we should annotate the desired Spring bean with `@Autowired`.
+  We can extend the annotation with `@Qualifier` if a specific version of the bean should be wired.


### PR DESCRIPTION
The supported resolvable parameters page wasn't very consistent.
It didn't contain all the options provided, nor the specifics on Event Handler parameters.
That's fixed in this pull request, which moves the set of parameters from the `event-handlers.md` file to the `supported-parameters-annotated-handlers.md` file.

On top of that, all grammar is validated, samples have been extended and minor additions for clarity have been done.

As this PR adds the `@SourceId` resolvable parameter too, this ticket resolves issue #152 