### PR TITLE
updating swagger url

### DIFF
--- a/axon-server/administration/admin-configuration/rest-api.md
+++ b/axon-server/administration/admin-configuration/rest-api.md
@@ -11,5 +11,5 @@ A list of the resources is provided below.
 | context | Maintenance of contexts | /v1/context |
 | cluster | Maintenance of clusters | /v1/cluster |
 
-The complete API documentation is available at {AXON\_SERVER\_URL}/swagger-ui.html
+The complete API documentation is available at {AXON\_SERVER\_URL}/swagger-ui/index.html
 


### PR DESCRIPTION
The swagger url in the currently published reference guide is not correct.  