### PR TITLE
Fixed the event parameter name in the EventHandler example

### DIFF
--- a/axon-framework/queries/query-dispatchers.md
+++ b/axon-framework/queries/query-dispatchers.md
@@ -111,7 +111,7 @@ This query handler will provide us with the list of GiftCard states. Once our Gi
 
 ```java
 @EventHandler
-public void on(RedeemedEvt evt) {
+public void on(RedeemedEvt event) {
     // 1.
     CardSummary summary = entityManager.find(CardSummary.class, event.getId());
     summary.setRemainingValue(summary.getRemainingValue() - event.getAmount());


### PR DESCRIPTION
... to match the usage in the method

The description code could never compile, and was misleading when first read (till we worked out it was a typo)
(It would be nice to have the example extracted from working code with a GitHub repo to back it)