### PR TITLE
Add notices on Dead-Letter Queue support for Sagas

### DIFF
--- a/axon-framework/events/event-processors/README.md
+++ b/axon-framework/events/event-processors/README.md
@@ -277,6 +277,15 @@ To that end, the supported dead-letter queue is a so-called `SequencedDeadLetter
 Integral to its design is to allow for queueing failed events and events that belong to a faulty sequence.
 It does so by maintaining a sequence identifier for each event, determined by the [sequencing policy](/axon-framework/events/event-processors/streaming.md#sequential-processing).
 
+> **Is there support for Sagas?**
+>
+> Currently, there is *no* support for using a dead-letter queue for [sagas](/axon-framework/sagas/README.md).
+> We've taken this decision as we cannot support a sequenced dead lettering approach as we do for regular event handling.
+> 
+> Furthermore, we cannot do this, as a saga's associations can vary widely between events.
+> Due to this, the sequence of events may change, breaking this level of support.
+> Hence, there's no way of knowing whether a next event in the stream does or does not belong to a saga.
+
 Note that you *cannot* share a dead-letter queue between different processing groups.
 Hence, each processing group you want to enable this behavior for should receive a unique dead-letter queue instance.
 


### PR DESCRIPTION
Add a notice stating why the `SequencedDeadLetterQueue` does not work for sagas for the time being.