### PR TITLE
Add an Upgrading to Axon Framework 4.7 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,30 @@ Welcome to the Axon Manual!
 
 Axon provides the Axon Framework and the Axon Server to help build applications centered on three core concepts - CQRS \(Command Query Responsibility Segregation\) / Event Sourcing and DDD \(Domain Driven Design\).
 
-While many types of applications can be built using Axon, it has proven to be very popular for microservices architectures. Axon provides an innovative and powerful way of sensibily evolving to event-driven microservices within a microservices architecture.
+While many types of applications can be built using Axon, it has proven to be very popular for microservices architectures. 
+Axon provides an innovative and powerful way of sensibly evolving to event-driven microservices within a microservices architecture.
 
-Please visit [the AxonIQ website](https://axoniq.io/) to learn more about AxonIQ and the Axon community. There, you will find information about Axon training, support options, upcoming and past events.
+Please visit [the AxonIQ website](https://axoniq.io/) to learn more about AxonIQ and the Axon community. 
+There, you will find information about Axon training, support options, upcoming and past events.
+
+> Breaking Changes in Axon Framework 4.7!
+> 
+> Against our normal approach towards minor releases, we sadly had to introduce breaking changes between Axon Framework 4.6 and 4.7.
+> Our apologies for this.
+> 
+> To help you with your upgrade we have constructed a dedicated page [here](axon-framework/upgrading-to-4-7.md) that helps you on your path to upgrade to 4.7.
+> If you find any irregularities concerning your upgrade, be sure to reach out to us!
 
 ## How to use this guide
 
 The Reference Guide is split into 4 sections
 
-| Section Name | Purpose |
-| :--- | :--- |
-| [Quick Start](getting-started/quick-start.md) | Details the Quick Start toolkit that Axon provides to easily familiarize with the basic concepts of Axon Framework and Axon Server |
-| [Axon Framework](axon-framework/introduction.md) | Details the building of Axon Framework based applications. |
-| [Axon Server](axon-server/introduction.md) | Details the Installation/Setup and Maintenance of Axon Server \(SE/EE\). |
-| [Axon Framework Extensions](release-notes/rn-extensions) | Details the extensions that Axon Framework provides to integrate with existing enterprise infrastructure\(s\). |
+| Section Name                                             | Purpose                                                                                                                            |
+|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------|
+| [Quick Start](getting-started/quick-start.md)            | Details the Quick Start toolkit that Axon provides to easily familiarize with the basic concepts of Axon Framework and Axon Server |
+| [Axon Framework](axon-framework/introduction.md)         | Details the building of Axon Framework based applications.                                                                         |
+| [Axon Server](axon-server/introduction.md)               | Details the Installation/Setup and Maintenance of Axon Server \(SE/EE\).                                                           |
+| [Axon Framework Extensions](release-notes/rn-extensions) | Details the extensions that Axon Framework provides to integrate with existing enterprise infrastructure\(s\).                     |
 
 ## License\(s\)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -53,6 +53,7 @@
 ## Axon Framework
 
 * [Introduction](axon-framework/introduction.md)
+* [Upgrading to 4.7](axon-framework/upgrading-to-4-7.md)
 * [Messaging Concepts](axon-framework/messaging-concepts/README.md)
   * [Anatomy of a Message](axon-framework/messaging-concepts/anatomy-message.md)
   * [Message Correlation](axon-framework/messaging-concepts/message-correlation.md)

--- a/axon-framework/introduction.md
+++ b/axon-framework/introduction.md
@@ -2,10 +2,19 @@
 
 This section of the reference guide intends to cover in detail the capabilities that the Axon Framework provides to help build applications based on [CQRS/DDD](../architecture-overview/#ddd-and-cqrs) and [Event Sourcing](../architecture-overview/event-sourcing.md)
 
+> Breaking Changes in Axon Framework 4.7!
+>
+> Against our normal approach towards minor releases, we sadly had to introduce breaking changes between Axon Framework 4.6 and 4.7.
+> Our apologies for this.
+>
+> To help you with your upgrade we have constructed a dedicated page [here](upgrading-to-4-7.md) that helps you on your path to upgrade to 4.7.
+> If you find any irregularities concerning your upgrade, be sure to reach out to us!
+
 A summary of the various sub-sections is given below.
 
 | Sub-Section                                           | Purpose                                                                  |
 |:------------------------------------------------------|:-------------------------------------------------------------------------|
+| [Upgrading to 4.7](upgrading-to-4-7.md)               | Step plan explaining how to upgrade to Axon Framework 4.7                |
 | [Messaging Concepts](messaging-concepts/)             | Conceptual overview of "Messages" within the Axon Framework              |
 | [Commands](axon-framework-commands/)                  | Command Message Development using the Axon Framework                     |
 | [Events](events/)                                     | Event Message Development using the Axon Framework                       |

--- a/axon-framework/upgrading-to-4-7.md
+++ b/axon-framework/upgrading-to-4-7.md
@@ -9,12 +9,12 @@ The breaking changes are related to the migration from `javax` to `jakarta` pack
 frameworks often used together with Axon.
 Depending on what you were using with 4.6.x version, there are three possible migration paths:
 
-1. From `javax` to `javax` - This is what you may want if you don’t want Spring 6 and Spring Boot 3 support and expect
-   things to stay the same.
-2. From `javax` to `jakarta` - This is what you will want if you also upgrade to Spring 6, Spring Boot 3, or another
-   framework that depends on `jakarta` packages.
-3. From `jakarta` to `jakarta` - This is what you will want if you have already moved to the
-   optional `[module-name]-jakarta` modules in Axon Framework 4.6.x.
+1. [From `javax` to `javax`](#steps-to-upgrade-from-javax-to-javax): 
+   This is what you may want if you don’t want Spring 6 and Spring Boot 3 support and expect things to stay the same.
+2. [From `javax` to `jakarta`](#steps-to-upgrade-from-javax-to-jakarta): 
+   This is what you will want if you also upgrade to Spring 6, Spring Boot 3, or another framework that depends on `jakarta` packages.
+3. [From `jakarta` to `jakarta`](#steps-to-upgrade-from-jakarta-to-jakarta): 
+   This is what you will want if you have already moved to the optional `[module-name]-jakarta` modules in Axon Framework 4.6.x.
 
 > **From `jakarta` to `javax`**
 >
@@ -83,7 +83,6 @@ back this new default of Hibernate:
 {% tab title="`persistence.xml` configuration" %}
 
 ```xml
-
 <persistence>
     <persistence-unit name="my-persistence-unit">
         <!-- omitting other configuration for simplicity... -->

--- a/axon-framework/upgrading-to-4-7.md
+++ b/axon-framework/upgrading-to-4-7.md
@@ -62,7 +62,8 @@ This is required since the `AbstractSagaEntry` has been deprecated in favor of t
 
 ### Step 1
 
-Remove any `javax` mentions in your codebase or replace them with respective `jakarta` ones.
+Remove most mentions of `javax` in your codebase and replace them with respective `jakarta` ones.
+Note that no every reference of `javax` is deprecated as part of the Javax-to-Jakarta switch, such as some `javax.annotation` and `javax.cache` mentions
 
 ### Step 2
 

--- a/axon-framework/upgrading-to-4-7.md
+++ b/axon-framework/upgrading-to-4-7.md
@@ -29,9 +29,6 @@ Adjust packages in `import` statements and FQCNs according to the new locations 
 
 | Axon 4.6.x                                                                        | Axon 4.7.x                                                                              |
 |-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| org.axonframework.eventsourcing.eventstore.EmbeddedEventStore                     | org.axonframework.eventsourcing.eventstore.legacyjpa.EmbeddedEventStore                 |
-| org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine              | org.axonframework.eventsourcing.eventstore.legacyjpa.JpaEventStorageEngine              |
-| org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver              | org.axonframework.eventsourcing.eventstore.legacyjpa.SQLErrorCodesResolver              |
 | org.axonframework.common.jpa.EntityManagerProvider                                | org.axonframework.common.legacyjpa.EntityManagerProvider                                |
 | org.axonframework.common.jpa.PagingJpaQueryIterable                               | org.axonframework.common.legacyjpa.PagingJpaQueryIterable                               |
 | org.axonframework.common.jpa.SimpleEntityManagerProvider                          | org.axonframework.common.legacyjpa.SimpleEntityManagerProvider                          |
@@ -40,13 +37,16 @@ Adjust packages in `import` statements and FQCNs according to the new locations 
 | org.axonframework.eventhandling.deadletter.jpa.JpaDeadLetter                      | org.axonframework.eventhandling.deadletter.legacyjpa.JpaDeadLetter                      |
 | org.axonframework.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue        | org.axonframework.eventhandling.deadletter.legacyjpa.JpaSequencedDeadLetterQueue        |
 | org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore                      | org.axonframework.eventhandling.tokenstore.legacyjpa.JpaTokenStore                      |
+| org.axonframework.eventsourcing.eventstore.EmbeddedEventStore                     | org.axonframework.eventsourcing.eventstore.legacyjpa.EmbeddedEventStore                 |
+| org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine              | org.axonframework.eventsourcing.eventstore.legacyjpa.JpaEventStorageEngine              |
+| org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver              | org.axonframework.eventsourcing.eventstore.legacyjpa.SQLErrorCodesResolver              |
+| org.axonframework.messaging.interceptors.BeanValidationInterceptor                | org.axonframework.messaging.interceptors.legacyvalidation.BeanValidationInterceptor     |
+| org.axonframework.messaging.interceptors.JSR303ViolationException                 | org.axonframework.messaging.interceptors.legacyvalidation.JSR303ViolationException      |
 | org.axonframework.modelling.command.GenericJpaRepository                          | org.axonframework.modelling.command.legacyjpa.GenericJpaRepository                      |
 | org.axonframework.modelling.saga.repository.jpa.JpaSagaStore                      | org.axonframework.modelling.saga.repository.legacyjpa.JpaSagaStore                      |
 | org.axonframework.springboot.autoconfig.JpaAutoConfiguration                      | org.axonframework.springboot.autoconfig.legacyjpa.JpaJavaxAutoConfiguration             |
 | org.axonframework.springboot.autoconfig.JpaEventStoreAutoConfiguration            | org.axonframework.springboot.autoconfig.legacyjpa.JpaJavaxEventStoreAutoConfiguration   |
 | org.axonframework.springboot.util.jpa.ContainerManagedEntityManagerProvider       | org.axonframework.springboot.util.legacyjpa.ContainerManagedEntityManagerProvider       |
-| org.axonframework.messaging.interceptors.BeanValidationInterceptor                | org.axonframework.messaging.interceptors.legacyvalidation.BeanValidationInterceptor     |
-| org.axonframework.messaging.interceptors.JSR303ViolationException                 | org.axonframework.messaging.interceptors.legacyvalidation.JSR303ViolationException      |
 
 ### Step 2
 

--- a/axon-framework/upgrading-to-4-7.md
+++ b/axon-framework/upgrading-to-4-7.md
@@ -1,0 +1,120 @@
+# Upgrading to Axon Framework 4.7
+
+Unfortunately, but necessarily, Axon Framework 4.7.0 introduces a few breaking changes.
+If you migrate from 4.6.x (or earlier) versions, you may need to make some adjustments to your code.
+If you start a greenfield Axon Framework project, there is nothing to worry about.
+You may safely skip the following information.
+
+The breaking changes are related to the migration from `javax` to `jakarta` packages both in Axon Framework and other
+frameworks often used together with Axon.
+Depending on what you were using with 4.6.x version, there are three possible migration paths:
+
+1. From `javax` to `javax` - This is what you may want if you don’t want Spring 6 and Spring Boot 3 support and expect
+   things to stay the same.
+2. From `javax` to `jakarta` - This is what you will want if you also upgrade to Spring 6, Spring Boot 3, or another
+   framework that depends on `jakarta` packages.
+3. From `jakarta` to `jakarta` - This is what you will want if you have already moved to the
+   optional `[module-name]-jakarta` modules in Axon Framework 4.6.x.
+
+> **From `jakarta` to `javax`**
+>
+> While technically possible, the `jakarta` to `javax` migration is not something you should do.
+> If you have already made an effort to switch to the new packages, it makes no sense to go back.
+
+## Steps to upgrade from `javax` to `javax`
+
+### Step 1
+
+Adjust packages in `import` statements and FQCNs according to the new locations mentioned below:
+
+| Axon 4.6.x                                                                        | Axon 4.7.x                                                                              |
+|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| org.axonframework.eventsourcing.eventstore.EmbeddedEventStore                     | org.axonframework.eventsourcing.eventstore.legacyjpa.EmbeddedEventStore                 |
+| org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine              | org.axonframework.eventsourcing.eventstore.legacyjpa.JpaEventStorageEngine              |
+| org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver              | org.axonframework.eventsourcing.eventstore.legacyjpa.SQLErrorCodesResolver              |
+| org.axonframework.common.jpa.EntityManagerProvider                                | org.axonframework.common.legacyjpa.EntityManagerProvider                                |
+| org.axonframework.common.jpa.PagingJpaQueryIterable                               | org.axonframework.common.legacyjpa.PagingJpaQueryIterable                               |
+| org.axonframework.common.jpa.SimpleEntityManagerProvider                          | org.axonframework.common.legacyjpa.SimpleEntityManagerProvider                          |
+| org.axonframework.eventhandling.deadletter.jpa.DeadLetterJpaConverter             | org.axonframework.eventhandling.deadletter.legacyjpa.DeadLetterJpaConverter             |
+| org.axonframework.eventhandling.deadletter.jpa.EventMessageDeadLetterJpaConverter | org.axonframework.eventhandling.deadletter.legacyjpa.EventMessageDeadLetterJpaConverter |
+| org.axonframework.eventhandling.deadletter.jpa.JpaDeadLetter                      | org.axonframework.eventhandling.deadletter.legacyjpa.JpaDeadLetter                      |
+| org.axonframework.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue        | org.axonframework.eventhandling.deadletter.legacyjpa.JpaSequencedDeadLetterQueue        |
+| org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore                      | org.axonframework.eventhandling.tokenstore.legacyjpa.JpaTokenStore                      |
+| org.axonframework.modelling.command.GenericJpaRepository                          | org.axonframework.modelling.command.legacyjpa.GenericJpaRepository                      |
+| org.axonframework.modelling.saga.repository.jpa.JpaSagaStore                      | org.axonframework.modelling.saga.repository.legacyjpa.JpaSagaStore                      |
+| org.axonframework.springboot.autoconfig.JpaAutoConfiguration                      | org.axonframework.springboot.autoconfig.legacyjpa.JpaJavaxAutoConfiguration             |
+| org.axonframework.springboot.autoconfig.JpaEventStoreAutoConfiguration            | org.axonframework.springboot.autoconfig.legacyjpa.JpaJavaxEventStoreAutoConfiguration   |
+| org.axonframework.springboot.util.jpa.ContainerManagedEntityManagerProvider       | org.axonframework.springboot.util.legacyjpa.ContainerManagedEntityManagerProvider       |
+| org.axonframework.messaging.interceptors.BeanValidationInterceptor                | org.axonframework.messaging.interceptors.legacyvalidation.BeanValidationInterceptor     |
+| org.axonframework.messaging.interceptors.JSR303ViolationException                 | org.axonframework.messaging.interceptors.legacyvalidation.JSR303ViolationException      |
+
+### Step 2
+
+If you have customized the `TokenEntry` or `AbstractTokenEntry`, rebase your changes on the current `TokenEntry`.
+This is required since the `AbstractTokenEntry` has been deprecated in favor of the `TokenEntry`.
+
+### Step 3
+
+If you have customized the `SagaEntry` or `AbstractSagaEntry`, rebase your changes on the current `SagaEntry`.
+This is required since the `AbstractSagaEntry` has been deprecated in favor of the `SagaEntry`.
+
+## Steps to upgrade from `javax` to `jakarta`
+
+### Step 1
+
+Remove any `javax` mentions in your codebase or replace them with respective `jakarta` ones.
+
+### Step 2
+
+If you are using any other frameworks together with Axon Framework (such as Spring, Hibernate, etc.) make sure to
+upgrade those to the respective versions supporting `jakarta` namespace.
+
+### Step 3
+
+If you migrate to Hibernate 6 and did **not** customize the sequence generator of the Framework's `domain_event_entry`
+and `association_value_entry`, you need to deal with Hibernates adjusted default sequence generator.
+In this case, your environment uses a so-called `hibernate_sequence` that is used for **all** your tables.
+However, Hibernate 6 will construct dedicated sequences per table using a sequence generator.
+
+Although we strongly recommend that you use a dedicated sequence generator per table, the easiest way forward to switch
+back this new default of Hibernate:
+
+{% tabs %}
+{% tab title="`persistence.xml` configuration" %}
+
+```xml
+
+<persistence>
+    <persistence-unit name="my-persistence-unit">
+        <!-- omitting other configuration for simplicity... -->
+        <properties>
+            <!-- ensure backward compatibility -->
+            <property name="hibernate.id.db_structure_naming_strategy" value="legacy"/>
+            <!-- omitting other properties for simplicity... -->
+        </properties>
+    </persistence-unit>
+</persistence>
+```
+
+{% endtab %}
+{% tab title="Spring Boot application properties" %}
+{% endtab %}
+
+```text
+spring.jpa.properties.hibernate.id.db_structure_naming_strategy=legacy
+#omitting other properties for simplicity...
+```
+
+{% endtabs %}
+
+## Steps to upgrade from `jakarta` to `jakarta`
+
+In your dependency configuration (Maven, Gradle, etc.) replace the `jakarta`-specific Axon Framework modules with the
+default ones:
+
+| Axon 4.6.x                 | Axon 4.7.x         |
+|----------------------------|--------------------|
+| axon-config-jakarta        | axon-config        |
+| axon-eventsourcing-jakarta | axon-eventsourcing |
+| axon-messaging-jakarta     | axon-messaging     |
+| axon-modelling-jakarta     | axon-modelling     |


### PR DESCRIPTION
Since it is extremely unusual for Axon Framework to introduce breaking changes in a minor release, this pull request adds a dedicated section under the Axon Framework documentation to help users in their upgrade. 
This page explains several scenarios a user may be in, providing a plan of attack to upgrade to 4.7.
Next to this, I've added a notice on the front page of the Reference Guide and on the base Axon Framework page to point out that 4.7 contains breaking changes.